### PR TITLE
[BE-55] feat : 토큰을 쿠키에 담아서 보내기

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -59,16 +59,10 @@ public class UserController {
     public ResponseEntity<TokenResponse> login(
             @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         TokenResponse tokenResponse = userLoginUseCase.execute(loginRequestDto);
-        Cookie accessCookie = new Cookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
-        accessCookie.setHttpOnly(true);
-        accessCookie.setPath("/");
-        accessCookie.setMaxAge(60 * 60 * 24 * 30);
+        Cookie accessCookie = setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
         response.addCookie(accessCookie);
 
-        Cookie refreshCookie = new Cookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(60 * 60 * 24 * 30);
+        Cookie refreshCookie = setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
         response.addCookie(refreshCookie);
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }
@@ -94,5 +88,13 @@ public class UserController {
             @RequestParam @Valid @PasswordValidate String password) {
         userRegisterUseCase.changePassword(password);
         return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
+    }
+
+    private Cookie setCookie(String name, String value) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24 * 30);
+        return cookie;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -62,13 +62,13 @@ public class UserController {
         Cookie accessCookie = new Cookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
         accessCookie.setHttpOnly(true);
         accessCookie.setPath("/");
-        accessCookie.setMaxAge(60 * 60 * 24 * 7);
+        accessCookie.setMaxAge(60 * 60 * 24 * 30);
         response.addCookie(accessCookie);
 
         Cookie refreshCookie = new Cookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
         refreshCookie.setHttpOnly(true);
         refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(60 * 60 * 24 * 7);
+        refreshCookie.setMaxAge(60 * 60 * 24 * 30);
         response.addCookie(refreshCookie);
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -16,6 +16,8 @@ import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,8 +56,20 @@ public class UserController {
 
     @Operation(summary = "로그인합니다.", description = "accessToken, refreshToken을 발급합니다.")
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequestDto loginRequestDto) {
+    public ResponseEntity<TokenResponse> login(
+            @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         TokenResponse tokenResponse = userLoginUseCase.execute(loginRequestDto);
+        Cookie accessCookie = new Cookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
+        accessCookie.setHttpOnly(true);
+        accessCookie.setPath("/");
+        accessCookie.setMaxAge(60 * 60 * 24 * 7);
+        response.addCookie(accessCookie);
+
+        Cookie refreshCookie = new Cookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(60 * 60 * 24 * 7);
+        response.addCookie(refreshCookie);
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }
 


### PR DESCRIPTION
### 개요
close #166 
- [#166]
###  작업사항
- Access / Refresh Token을 Cookie 담아서 repsonse로 보내주었습니다.
### 변경로직
```java
Cookie accessCookie = new Cookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
        accessCookie.setHttpOnly(true);
        accessCookie.setPath("/");
        accessCookie.setMaxAge(60 * 60 * 24 * 30);
        response.addCookie(accessCookie);

        Cookie refreshCookie = new Cookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
        refreshCookie.setHttpOnly(true);
        refreshCookie.setPath("/");
        refreshCookie.setMaxAge(60 * 60 * 24 * 30);
        response.addCookie(refreshCookie);
``` 

### reference

- 