### PR TITLE
[BE-58] refactor : 토큰 쿠키에 담기

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -60,8 +60,10 @@ public class UserController {
     public ResponseEntity<TokenResponse> login(
             @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         TokenResponse tokenResponse = userLoginUseCase.execute(loginRequestDto);
-        response.addHeader("Set-Cookie", SecurityUtils.setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken()).toString()
-                + "; " + SecurityUtils.setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken()).toString());
+        response.addHeader("Set-Cookie", new StringBuilder(SecurityUtils.setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken()).toString())
+                .append("; ")
+                .append(SecurityUtils.setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken()))
+                .toString());
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -6,6 +6,7 @@ import static com.econovation.recruitcommon.consts.RecruitStatic.PASSWORD_SUCCES
 import com.econovation.recruit.api.interviewer.docs.InterviewerExceptionDocs;
 import com.econovation.recruit.api.user.usecase.UserLoginUseCase;
 import com.econovation.recruit.api.user.usecase.UserRegisterUseCase;
+import com.econovation.recruit.utils.SecurityUtils;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitcommon.annotation.DevelopOnlyApi;
 import com.econovation.recruitcommon.annotation.PasswordValidate;
@@ -59,10 +60,8 @@ public class UserController {
     public ResponseEntity<TokenResponse> login(
             @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         TokenResponse tokenResponse = userLoginUseCase.execute(loginRequestDto);
-        Cookie accessCookie = setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken());
-        response.addCookie(accessCookie);
-        Cookie refreshCookie = setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken());
-        response.addCookie(refreshCookie);
+        response.addHeader("Set-Cookie", SecurityUtils.setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken()).toString()
+                + "; " + SecurityUtils.setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken()).toString());
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }
 
@@ -87,14 +86,5 @@ public class UserController {
             @RequestParam @Valid @PasswordValidate String password) {
         userRegisterUseCase.changePassword(password);
         return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
-    }
-
-    private Cookie setCookie(String name, String value) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24 * 30);
-        cookie.setSecure(true);
-        return cookie;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -17,7 +17,6 @@ import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -60,10 +59,17 @@ public class UserController {
     public ResponseEntity<TokenResponse> login(
             @RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
         TokenResponse tokenResponse = userLoginUseCase.execute(loginRequestDto);
-        response.addHeader("Set-Cookie", new StringBuilder(SecurityUtils.setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken()).toString())
-                .append("; ")
-                .append(SecurityUtils.setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken()))
-                .toString());
+        response.addHeader(
+                "Set-Cookie",
+                new StringBuilder(
+                                SecurityUtils.setCookie(
+                                                "ACCESS_TOKEN", tokenResponse.getAccessToken())
+                                        .toString())
+                        .append("; ")
+                        .append(
+                                SecurityUtils.setCookie(
+                                        "REFRESH_TOKEN", tokenResponse.getRefreshToken()))
+                        .toString());
         return new ResponseEntity<>(tokenResponse, HttpStatus.OK);
     }
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/SecurityUtils.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/SecurityUtils.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseCookie;
 
 public class SecurityUtils {
     public static ResponseCookie setCookie(String name, String value) {
-        return ResponseCookie.from(name,value)
+        return ResponseCookie.from(name, value)
                 .secure(true)
                 .sameSite("None")
                 .httpOnly(true)

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/SecurityUtils.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/SecurityUtils.java
@@ -1,0 +1,15 @@
+package com.econovation.recruit.utils;
+
+import org.springframework.http.ResponseCookie;
+
+public class SecurityUtils {
+    public static ResponseCookie setCookie(String name, String value) {
+        return ResponseCookie.from(name,value)
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .maxAge(2592000)
+                .path("/")
+                .build();
+    }
+}


### PR DESCRIPTION
### 개요
close #170 
- [#170]

###  작업사항
- ResponseCookie를 사용해 Cookie를 만들고 toString으로 문자열로 만든 후 Response Header의 Set-cookie에 추가했습니다.

### 변경로직
```java
public class SecurityUtils {
    public static ResponseCookie setCookie(String name, String value) {
        return ResponseCookie.from(name,value)
                .secure(true)
                .sameSite("None")
                .httpOnly(true)
                .maxAge(2592000)
                .path("/")
                .build();
    }
}
``` 

```java
 response.addHeader("Set-Cookie", SecurityUtils.setCookie("ACCESS_TOKEN", tokenResponse.getAccessToken()).toString()
                + "; " + SecurityUtils.setCookie("REFRESH_TOKEN", tokenResponse.getRefreshToken()).toString());
``` 

### reference

- 