### PR TITLE
[BE-84] bug : 특정 요청 filter ignore 안되는 버그

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
@@ -1,5 +1,6 @@
 package com.econovation.recruit.api.config.security;
 
+import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,13 +13,13 @@ import org.springframework.stereotype.Component;
 public class FilterConfig
         extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
-    private final JwtTokenFilter jwtTokenFilter;
     //    private final AccessDeniedFilter accessDeniedFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public void configure(HttpSecurity builder) {
-        builder.addFilterBefore(jwtTokenFilter, BasicAuthenticationFilter.class);
+        builder.addFilterBefore(new JwtTokenFilter(jwtTokenProvider), BasicAuthenticationFilter.class);
         builder.addFilterBefore(jwtExceptionFilter, JwtTokenFilter.class);
         //        builder.addFilterBefore(accessDeniedFilter, FilterSecurityInterceptor.class);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
@@ -19,7 +19,8 @@ public class FilterConfig
 
     @Override
     public void configure(HttpSecurity builder) {
-        builder.addFilterBefore(new JwtTokenFilter(jwtTokenProvider), BasicAuthenticationFilter.class);
+        builder.addFilterBefore(
+                new JwtTokenFilter(jwtTokenProvider), BasicAuthenticationFilter.class);
         builder.addFilterBefore(jwtExceptionFilter, JwtTokenFilter.class);
         //        builder.addFilterBefore(accessDeniedFilter, FilterSecurityInterceptor.class);
     }


### PR DESCRIPTION
### 개요
close #224 

###  작업사항
- custom filter를 bean으로 주입받는 것 이 아닌 new로 생성해서 BasicAuthenticationFilter 필터 이전에 추가 


web.ignoring().antMatchers(...)는 파라미터로 전달하는 패턴에 대해 security filter chain을 생략하도록 하는데, custom filter를 빈으로 등록하게 되면 해당 필터가 security filter chain에 포함되는 게 아니라 default filter chain에 포함되게 되기 때문에 해당 패턴에 접근하게 됐을 때 그대로 필터를 적용하게 되는 것이다.


### 변경로직
```java
@Override
    public void configure(HttpSecurity builder) {
        builder.addFilterBefore(
                new JwtTokenFilter(jwtTokenProvider), BasicAuthenticationFilter.class);
        builder.addFilterBefore(jwtExceptionFilter, JwtTokenFilter.class);
        //        builder.addFilterBefore(accessDeniedFilter, FilterSecurityInterceptor.class);
    }
``` 


### reference

- 참고 : https://velog.io/@gkdud583/WebSecurity-ignoring-Security-filter-chain-%EC%A0%81%EC%9A%A9%EB%90%98%EB%8A%94-%EB%AC%B8%EC%A0%9C
