### PR TITLE
[BE-85] Servlet Filter ignoring #226

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/ServletFilterConfiguration.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/ServletFilterConfiguration.java
@@ -1,0 +1,25 @@
+package com.econovation.recruit.api.config.security;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class ServletFilterConfiguration {
+    @Bean
+    public FilterRegistrationBean<JwtTokenFilter> registrationJwtTokenFileter(
+            JwtTokenFilter filter) {
+        FilterRegistrationBean<JwtTokenFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtExceptionFilter> registrationJwtExceptionFilter(
+            JwtExceptionFilter filter) {
+        FilterRegistrationBean<JwtExceptionFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}


### PR DESCRIPTION
### 개요
- close #226 

###  작업사항
- 진혁님이 작업하신 web ignoring을 적용하면 만료된 토큰이 들어있을 경우 서블릿 필터를 거쳐 403에러가 발생하는 것을 확인할 수 있습니다.
- 서블릿필터는 JwtExceptionFilter가 적용된 것을 확인해서 프록시 빈이 아닌 경우 enabled=false로 변경해주었습니다.