### PR TITLE
[BE-91] 칸반보드 기수별 조회 로직 수정

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -12,6 +12,7 @@ import com.econovation.recruitdomain.common.aop.domainEvent.Events;
 import com.econovation.recruitdomain.common.events.WorkCardDeletedEvent;
 import com.econovation.recruitdomain.domains.applicant.adaptor.AnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantProhibitDeleteException;
 import com.econovation.recruitdomain.domains.board.domain.Board;
 import com.econovation.recruitdomain.domains.board.domain.CardType;
@@ -28,10 +29,13 @@ import com.econovation.recruitdomain.out.LabelLoadPort;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.swing.text.html.Option;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +48,7 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
     private final ApplicantQueryUseCase applicantQueryUseCase;
     private final LabelLoadPort labelLoadPort;
     private final AnswerAdaptor answerAdaptor;
+    private final MongoAnswerAdaptor mongoAnswerAdaptor;
 
     @Override
     @Transactional(readOnly = true)
@@ -71,8 +76,13 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
                 .filter(
                         board -> {
                             Long cardId = board.getCardId();
-                            String applicantId = cardLoadPort.findById(cardId).getApplicantId();
-                            return yearByAnswerIdMap.get(applicantId).equals(year);
+
+                            if(cardId!=null) {
+                                String applicantId = cardLoadPort.findById(cardId).getApplicantId();
+                                return yearByAnswerIdMap.get(applicantId).equals(year);
+                            }
+
+                            return false;
                         })
                 .toList();
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -72,13 +72,18 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
         Map<String, Integer> yearByAnswerIdMap = mongoAnswers.stream()
                 .collect(Collectors.toMap(MongoAnswer::getId, MongoAnswer::getYear));
 
+        List<Card> cards = cardLoadPort.findAll();
+
+        Map<Long, String> answerIdByCardIdMap = cards.stream()
+                .collect(Collectors.toMap(Card::getId, Card::getApplicantId));
+
         boards = boards.stream()
                 .filter(
                         board -> {
                             Long cardId = board.getCardId();
 
                             if(cardId!=null) {
-                                String applicantId = cardLoadPort.findById(cardId).getApplicantId();
+                                String applicantId = answerIdByCardIdMap.get(cardId);
                                 return yearByAnswerIdMap.get(applicantId).equals(year);
                             }
 
@@ -86,7 +91,7 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
                         })
                 .toList();
 
-        List<Card> cards =
+        cards =
                 cardLoadPort.findByIdIn(
                         boards.stream().map(Board::getCardId).collect(Collectors.toList()));
 


### PR DESCRIPTION
### 개요
close #241 

###  작업사항
1. stream 내부에서 데이터베이스에 여러 번 접근하는 로직을 수정하였습니다.
  - 처음 작성한 코드의 경우에 기존 데이터 베이스에 존재하는 모든 board를 가져와서, board에 매핑된 card_id를 가져와, 데이터베이스에서 card_id에 해당하는 Card를 직접 가져옵니다. 
  - 그 후, Card와 매핑된 applicantId를 다시 데이터베이스에서 조회하여, year와 일치하는 것만 필터링 합니다.
  - 이 과정을 stream으로 변환하여, stream 내부에서 데이터베이스를 조회하였으나 데이터베이스에 여러번 접근하기 때문에 비효율적이라고 판단하여 한 번의 데이터베이스 접근으로 데이터를 가져온 후 이 데이터를 활용하는 방향으로 코드를 수정하였습니다.

2. board에 매핑된 card_id가 null인 경우 분기처리를 하였습니다.

### 변경로직
- Card 테이블에 존재하는 모든 Card Row들을 가져와 List로 만든 후, stream으로 이용하여 key가 cardId, value가 applicantId인 Map을 만들었습니다.
- 이 Map을 사용하여, 파라미터로 받은 year와 일치하는 board만 필터링합니다.
```java
List<Board> boards = boardLoadUseCase.getBoardByColumnsIds(columnsIds);

        List<MongoAnswer> mongoAnswers = answerAdaptor.findAll();

        Map<String, Integer> yearByAnswerIdMap = mongoAnswers.stream()
                .collect(Collectors.toMap(MongoAnswer::getId, MongoAnswer::getYear));

        List<Card> cards = cardLoadPort.findAll();

        Map<Long, String> answerIdByCardIdMap = cards.stream()
                .collect(Collectors.toMap(Card::getId, Card::getApplicantId));

        boards = boards.stream()
                .filter(
                        board -> {
                            Long cardId = board.getCardId();

                            if(cardId!=null) {
                                String applicantId = answerIdByCardIdMap.get(cardId);
                                return yearByAnswerIdMap.get(applicantId).equals(year);
                            }

                            return false;
                        })
                .toList();

        cards =
                cardLoadPort.findByIdIn(
                        boards.stream().map(Board::getCardId).collect(Collectors.toList()));
```


### reference

- 