### PR TITLE
[BE-91] null 처리 Optional 형태로 변경

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -35,8 +35,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.swing.text.html.Option;
-
 @Service
 @RequiredArgsConstructor
 public class CardService implements CardRegisterUseCase, CardLoadUseCase {
@@ -79,16 +77,12 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
 
         boards = boards.stream()
                 .filter(
-                        board -> {
-                            Long cardId = board.getCardId();
-
-                            if(cardId!=null) {
-                                String applicantId = answerIdByCardIdMap.get(cardId);
-                                return yearByAnswerIdMap.get(applicantId).equals(year);
-                            }
-
-                            return false;
-                        })
+                        board ->
+                                Optional.ofNullable(board.getCardId())
+                                .map(id -> answerIdByCardIdMap.getOrDefault(id, null))
+                                .map(id -> yearByAnswerIdMap.getOrDefault(id, null))
+                                .map(y -> y.equals(year))
+                                .orElse(false))
                 .toList();
 
         cards =


### PR DESCRIPTION
### 개요
close #241 

###  작업사항
- 처음에 칸반보드를 기수별로 조회하도록 로직을 수정했을 때, null 처리를 if문으로 했습니다. 하지만 if문으로 했을 경우에 if문 내부에서도 null 값 처리를 해주어야 하는 상황이 있었는데, 이 경우 코드가 복잡해지고 지저분해질 경우가 있어서 Optional을 사용하는 방식으로 변경하였습니다.

### 변경로직
- 

```java
boards = boards.stream()
                .filter(
                        board ->
                                Optional.ofNullable(board.getCardId())
                                .map(id -> answerIdByCardIdMap.getOrDefault(id, null))
                                .map(id -> yearByAnswerIdMap.getOrDefault(id, null))
                                .map(y -> y.equals(year))
                                .orElse(false))
                .toList();
```


### reference

- 