### PR TITLE
[BE-91] Optional 구문 수정 및 기본 board 는 true 반환

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -77,12 +77,16 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
 
         boards = boards.stream()
                 .filter(
-                        board ->
-                                Optional.ofNullable(board.getCardId())
+                        board ->{
+                            if(board.getId()==1 || board.getId()==2 || board.getId()==3) {
+                                return true;
+                            }
+                            return Optional.ofNullable(board.getCardId())
                                     .map(answerIdByCardIdMap::get)
                                     .map(yearByAnswerIdMap::get)
                                     .map(y -> y.equals(year))
-                                    .orElse(false))
+                                    .orElse(false);
+                        })
                 .toList();
 
         cards =

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -79,10 +79,10 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
                 .filter(
                         board ->
                                 Optional.ofNullable(board.getCardId())
-                                .map(id -> answerIdByCardIdMap.getOrDefault(id, null))
-                                .map(id -> yearByAnswerIdMap.getOrDefault(id, null))
-                                .map(y -> y.equals(year))
-                                .orElse(false))
+                                    .map(answerIdByCardIdMap::get)
+                                    .map(yearByAnswerIdMap::get)
+                                    .map(y -> y.equals(year))
+                                    .orElse(false))
                 .toList();
 
         cards =


### PR DESCRIPTION
### 개요
close #241 

###  작업사항
- Optional 구문을 메소드 참조로 수정하였으며, 기본 board (board_id=1 or 2 or 3)은 무조건 포함되도록 로직을 수정하였습니다.

### 변경로직
```java
boards = boards.stream()
                .filter(
                        board ->{
                            if(board.getId()==1 || board.getId()==2 || board.getId()==3) {
                                return true;
                            }
                            return Optional.ofNullable(board.getCardId())
                                    .map(answerIdByCardIdMap::get)
                                    .map(yearByAnswerIdMap::get)
                                    .map(y -> y.equals(year))
                                    .orElse(false);
                        })
                .toList();
```


### reference

- 