### PR TITLE
[BE-91] 면접 기록 지원 기수별로 조회하도록 수정

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
@@ -55,8 +55,8 @@ public class RecordController {
     @ApiErrorExceptionsExample(RecordFindExceptionDocs.class)
     @GetMapping("/page/{page}/records")
     public ResponseEntity<RecordsViewResponseDto> findAll(
-            @PathVariable(name = "page") Integer page, @ParameterObject String sortType) {
-        return new ResponseEntity<>(recordUseCase.execute(page, sortType), HttpStatus.OK);
+            @PathVariable(name = "page") Integer page, @ParameterObject String sortType, @ParameterObject Integer year) {
+        return new ResponseEntity<>(recordUseCase.execute(page, year, sortType), HttpStatus.OK);
     }
 
     @Operation(summary = "지원자의 면접기록을 전부 조회합니다")

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
@@ -63,7 +63,7 @@ public class RecordService implements RecordUseCase {
 
         List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
         List<Score> scores = scoreLoadPort.findByApplicantIds(applicantIds);
-        List<MongoAnswer> applicants = applicantQueryUseCase.execute(applicantIds).stream().filter(applicant -> applicant.getYear().equals(year)).toList();
+        List<MongoAnswer> applicants = applicantQueryUseCase.execute(applicantIds).stream().filter(applicant ->year == null || applicant.getYear().equals(year)).toList();
 
         if (result.isEmpty() || applicants.isEmpty()) {
             return RecordsViewResponseDto.of(
@@ -76,13 +76,13 @@ public class RecordService implements RecordUseCase {
         Map<String, Integer> yearByAnswerIdMap = applicants.stream().collect(Collectors.toMap(MongoAnswer::getId, MongoAnswer::getYear));
         Map<String, Double> scoreMap =
                 scores.stream()
-                        .filter(score -> yearByAnswerIdMap.get(score.getApplicantId()).equals(year))
+                        .filter(score ->year == null || yearByAnswerIdMap.get(score.getApplicantId()).equals(year))
                         .collect(
                                 Collectors.groupingBy(
                                         Score::getApplicantId,
                                         Collectors.averagingDouble(Score::getScore)));
 
-        result = result.stream().filter(record ->
+        result = result.stream().filter(record -> year == null ||
             Optional.ofNullable(record.getApplicantId())
                     .map(yearByAnswerIdMap::get)
                     .map(y -> y.equals(year))

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
@@ -16,12 +16,8 @@ import com.econovation.recruitdomain.domains.score.domain.Score;
 import com.econovation.recruitdomain.out.RecordLoadPort;
 import com.econovation.recruitdomain.out.RecordRecordPort;
 import com.econovation.recruitdomain.out.ScoreLoadPort;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -61,10 +57,15 @@ public class RecordService implements RecordUseCase {
      *     Records를 모두 조회합니다 )
      */
     @Override
-    public RecordsViewResponseDto execute(Integer page, String sortType) {
+    public RecordsViewResponseDto execute(Integer page, Integer year, String sortType) {
         List<Record> result = recordLoadPort.findAll(page);
         PageInfo pageInfo = getPageInfo(page);
-        if (result.isEmpty()) {
+
+        List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
+        List<Score> scores = scoreLoadPort.findByApplicantIds(applicantIds);
+        List<MongoAnswer> applicants = applicantQueryUseCase.execute(applicantIds).stream().filter(applicant -> applicant.getYear().equals(year)).toList();
+
+        if (result.isEmpty() || applicants.isEmpty()) {
             return RecordsViewResponseDto.of(
                     pageInfo,
                     Collections.emptyList(),
@@ -72,15 +73,24 @@ public class RecordService implements RecordUseCase {
                     Collections.emptyList());
         }
 
-        List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
-        List<Score> scores = scoreLoadPort.findByApplicantIds(applicantIds);
+        Map<String, Integer> yearByAnswerIdMap = applicants.stream().collect(Collectors.toMap(MongoAnswer::getId, MongoAnswer::getYear));
         Map<String, Double> scoreMap =
                 scores.stream()
+                        .filter(score -> yearByAnswerIdMap.get(score.getApplicantId()).equals(year))
                         .collect(
                                 Collectors.groupingBy(
                                         Score::getApplicantId,
                                         Collectors.averagingDouble(Score::getScore)));
-        List<MongoAnswer> applicants = applicantQueryUseCase.execute(applicantIds);
+
+        result = result.stream().filter(record ->
+            Optional.ofNullable(record.getApplicantId())
+                    .map(yearByAnswerIdMap::get)
+                    .map(y -> y.equals(year))
+                    .orElse(false)
+        )
+        .toList();
+
+        applicants = new ArrayList<>(applicants); // Unmodifiable List일 경우 Sort 불가. stream().toList()의 결과는 Unmodifiable List
 
         if (sortType.equals("score")) {
             List<Record> records = sortRecordsByScoresDesc(result, scoreMap);

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/usecase/RecordUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/usecase/RecordUseCase.java
@@ -11,7 +11,7 @@ public interface RecordUseCase {
 
     List<Record> findAll();
 
-    RecordsViewResponseDto execute(Integer page, String sortType);
+    RecordsViewResponseDto execute(Integer page, Integer year, String sortType);
 
     Record findByApplicantId(String applicantId);
 


### PR DESCRIPTION
### 개요
close #241 

###  작업사항
- RecordController, RecordService, RecordUseCase에서 면접 기록 목록을 조회할 때, 지원 기수를 파라미터로 받도록 수정하였습니다.
- 또한, 기존 API와의 호환성을 위해서, year 파라미터가 넘어오지 않을 경우 전체 면접 기록을 조회할 수 있도록 하였습니다.


### 변경로직
```java
public RecordsViewResponseDto execute(Integer page, Integer year, String sortType) {
        List<Record> result = recordLoadPort.findAll(page);
        PageInfo pageInfo = getPageInfo(page);

        List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
        List<Score> scores = scoreLoadPort.findByApplicantIds(applicantIds);
        List<MongoAnswer> applicants = applicantQueryUseCase.execute(applicantIds).stream().filter(applicant ->year == null || applicant.getYear().equals(year)).toList();

        if (result.isEmpty() || applicants.isEmpty()) {
            return RecordsViewResponseDto.of(
                    pageInfo,
                    Collections.emptyList(),
                    Collections.emptyMap(),
                    Collections.emptyList());
        }

        Map<String, Integer> yearByAnswerIdMap = applicants.stream().collect(Collectors.toMap(MongoAnswer::getId, MongoAnswer::getYear));
        Map<String, Double> scoreMap =
                scores.stream()
                        .filter(score ->year == null || yearByAnswerIdMap.get(score.getApplicantId()).equals(year))
                        .collect(
                                Collectors.groupingBy(
                                        Score::getApplicantId,
                                        Collectors.averagingDouble(Score::getScore)));

        result = result.stream().filter(record -> year == null ||
            Optional.ofNullable(record.getApplicantId())
                    .map(yearByAnswerIdMap::get)
                    .map(y -> y.equals(year))
                    .orElse(false)
        )
        .toList();

        applicants = new ArrayList<>(applicants); // Unmodifiable List일 경우 Sort 불가. stream().toList()의 결과는 Unmodifiable List

        if (sortType.equals("score")) {
            List<Record> records = sortRecordsByScoresDesc(result, scoreMap);
            return RecordsViewResponseDto.of(pageInfo, records, scoreMap, applicants);
        } else {
            List<Record> records = sortRecordsByApplicantsAndSortType(result, applicants, sortType);
            return RecordsViewResponseDto.of(pageInfo, records, scoreMap, applicants);
        }
    }
```


### reference

- 