### PR TITLE
[BE-91] 칸반보드 API에서 year가 null일 경우 전체 조회 할 수 있도록 변경

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/controller/BoardRestController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/controller/BoardRestController.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -162,7 +163,7 @@ public class BoardRestController {
     @GetMapping("/navigations/{navigation-id}/boards")
     public ResponseEntity<List<BoardCardResponseDto>> getBoardByNavigationId(
             @PathVariable("navigation-id") Integer navigationId,
-            @RequestParam("year") Integer year) {
+            @ParameterObject Integer year) {
         return new ResponseEntity<>(cardLoadUseCase.getByNavigationId(navigationId, year), HttpStatus.OK);
     }
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/CardService.java
@@ -81,7 +81,7 @@ public class CardService implements CardRegisterUseCase, CardLoadUseCase {
                             if(board.getId()==1 || board.getId()==2 || board.getId()==3) {
                                 return true;
                             }
-                            return Optional.ofNullable(board.getCardId())
+                            return year == null || Optional.ofNullable(board.getCardId())
                                     .map(answerIdByCardIdMap::get)
                                     .map(yearByAnswerIdMap::get)
                                     .map(y -> y.equals(year))


### PR DESCRIPTION
### 개요
close #241 

###  작업사항
- 기존 API와 호환성을 위해서 year 파라미터가 넘어 오지 않을 경우, 전체 조회를 할 수 있도록 수정하였습니다.

### 변경로직
```java
Map<Long, String> answerIdByCardIdMap = cards.stream()
                .collect(Collectors.toMap(Card::getId, Card::getApplicantId));

        boards = boards.stream()
                .filter(
                        board ->{
                            if(board.getId()==1 || board.getId()==2 || board.getId()==3) {
                                return true;
                            }
                            return year == null || Optional.ofNullable(board.getCardId())
                                    .map(answerIdByCardIdMap::get)
                                    .map(yearByAnswerIdMap::get)
                                    .map(y -> y.equals(year))
                                    .orElse(false);
                        })
                .toList();
```


### reference

- 