### PR TITLE
[BE-93] 지원서 합/불 관리자 페이지 조회 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -1,11 +1,9 @@
 package com.econovation.recruit.api.applicant.controller;
 
-import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANT_SUCCESS_REGISTER_MESSAGE;
-import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
-
 import com.econovation.recruit.api.applicant.command.CreateAnswerCommand;
 import com.econovation.recruit.api.applicant.docs.CreateApplicantExceptionDocs;
 import com.econovation.recruit.api.applicant.dto.AnswersResponseDto;
+import com.econovation.recruit.api.applicant.dto.GetApplicantsStatusResponse;
 import com.econovation.recruit.api.applicant.usecase.ApplicantCommandUseCase;
 import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
 import com.econovation.recruit.api.applicant.usecase.TimeTableLoadUseCase;
@@ -20,11 +18,6 @@ import com.econovation.recruitdomain.domains.timetable.domain.TimeTable;
 import com.econovation.recruitinfrastructure.apache.CommonsEmailSender;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.commandhandling.gateway.CommandGateway;
@@ -33,6 +26,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANT_SUCCESS_REGISTER_MESSAGE;
+import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -155,5 +157,13 @@ public class ApplicantController {
         Map<String, String> response = new HashMap<>();
         response.put(PASS_STATE_KEY, state);
         return new ResponseEntity(response,HttpStatus.OK);
+    }
+
+    @Operation(summary = "지원서의 합/불 상태를 조회합니다. (합/불 관리자 페이지 전용)")
+    @GetMapping("year/{year}/applicants/pass-state")
+    public ResponseEntity<List<GetApplicantsStatusResponse>> getApplicantsStatus(@PathVariable("year") Integer year,
+                                                                           @RequestParam("order") String sortType) {
+        List<GetApplicantsStatusResponse> result = applicantQueryUseCase.getApplicantsStatus(year, sortType);
+        return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
@@ -1,0 +1,34 @@
+package com.econovation.recruit.api.applicant.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Map;
+
+import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class GetApplicantsStatusResponse {
+    private String field1;
+    private String field2;
+    private String field3;
+    private String name;
+    private String id;
+    private Integer year;
+    private String state;
+
+    public static GetApplicantsStatusResponse of(Map<String,Object> result) {
+        return GetApplicantsStatusResponse.builder()
+                .field1((String) result.get("field1"))
+                .field2((String) result.get("field2"))
+                .field3((String) result.get("field3"))
+                .name((String) result.get("name"))
+                .id((String) result.get("id"))
+                .year((Integer) result.get("year"))
+                .state(result.get(PASS_STATE_KEY).toString())
+                .build();
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -2,6 +2,7 @@ package com.econovation.recruit.api.applicant.service;
 
 import com.econovation.recruit.api.applicant.aggregate.AnswerAggregate;
 import com.econovation.recruit.api.applicant.dto.AnswersResponseDto;
+import com.econovation.recruit.api.applicant.dto.GetApplicantsStatusResponse;
 import com.econovation.recruit.api.applicant.query.AnswerQuery;
 import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
 import com.econovation.recruit.utils.sort.SortHelper;
@@ -48,16 +49,7 @@ public class ApplicantService implements ApplicantQueryUseCase {
     public AnswersResponseDto execute(Integer year, Integer page, String sortType) {
         PageInfo pageInfo = getPageInfo(year, page);
         List<MongoAnswer> result = answerAdaptor.findByYear(year, page);
-        result.forEach(answer -> answer.getQna().put(PASS_STATE_KEY, answer.getApplicantStateOrDefault()));
-
-        sortHelper.sort(result, sortType);
-        List<Map<String, Object>> sortedResult = result.stream().map(MongoAnswer::getQna).toList();
-        // answer id를 각 map에 추가
-        sortedResult.forEach(
-                map -> {
-                    map.put("id", result.get(sortedResult.indexOf(map)).getId());
-                });
-
+        List<Map<String, Object>> sortedResult = sortAndAddIds(result, sortType);
         if (sortedResult.isEmpty()) {
             return AnswersResponseDto.of(Collections.emptyList(), pageInfo);
         }
@@ -180,5 +172,23 @@ public class ApplicantService implements ApplicantQueryUseCase {
     public List<Map<String, Object>> execute(List<String> fields, Integer page) {
         List<MongoAnswer> byYear = answerAdaptor.findByYear(year, page);
         return splitByAnswers(fields, byYear);
+    }
+
+    @Override
+    public List<GetApplicantsStatusResponse> getApplicantsStatus(Integer year, String sortType) {
+        List<MongoAnswer> result = answerAdaptor.findByYear(year);
+        List<Map<String, Object>> sortedResult = sortAndAddIds(result, sortType);
+        return sortedResult.stream().map(GetApplicantsStatusResponse::of).toList();
+    }
+
+    private List<Map<String, Object>> sortAndAddIds(List<MongoAnswer> result, String sortType) {
+        sortHelper.sort(result, sortType);
+        List<Map<String, Object>> sortedResult = result.stream().map(MongoAnswer::getQna).toList();
+        sortedResult.forEach(
+                map -> {
+                    map.put("id", result.get(sortedResult.indexOf(map)).getId());
+                    map.put(PASS_STATE_KEY, result.get(sortedResult.indexOf(map)).getApplicantStateOrDefault());
+                });
+        return sortedResult;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.applicant.usecase;
 
 import com.econovation.recruit.api.applicant.dto.AnswersResponseDto;
+import com.econovation.recruit.api.applicant.dto.GetApplicantsStatusResponse;
 import com.econovation.recruitcommon.annotation.UseCase;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import java.util.List;
@@ -26,4 +27,6 @@ public interface ApplicantQueryUseCase {
     Map<String, Map<String, Object>> findAllApplicantVo(List<String> fields);
 
     AnswersResponseDto search(Integer page, String searchKeyword);
+
+    List<GetApplicantsStatusResponse> getApplicantsStatus(Integer year, String sortType);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/interviewer/controller/InterviewerController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/interviewer/controller/InterviewerController.java
@@ -38,7 +38,7 @@ public class InterviewerController {
     @Operation(description = "Interviewer 전체 조회", summary = "면접관 전체 조회")
     @ApiErrorExceptionsExample(InterviewerExceptionDocs.class)
     @GetMapping("/interviewers")
-    public ResponseEntity<List<InterviewerResponseDto>> findAll(@ParameterObject String order) {
+    public ResponseEntity<List<InterviewerResponseDto>> findAll(@ParameterObject String order, @RequestParam(required = false) List<String> roles) {
         List<InterviewerResponseDto> interviewers = interviewerUseCase.findAll(order);
         return new ResponseEntity(interviewers, HttpStatus.OK);
     }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -44,6 +44,13 @@ public class AnswerAdaptor {
         return mongoTemplate.find(query, MongoAnswer.class);
     }
 
+    public List<MongoAnswer> findByYear(Integer year) {
+        Query query =
+                new Query()
+                        .addCriteria(Criteria.where("year").is(year));
+        return mongoTemplate.find(query, MongoAnswer.class);
+    }
+
     public long getTotalCountByYear(Integer year) {
         return mongoTemplate.count(Query.query(Criteria.where("year").is(year)), MongoAnswer.class);
     }


### PR DESCRIPTION
### 개요
close #256 

###  작업사항
- 기수별로 지원서를 조회하는 쿼리 추가(페이지네이션 X)
- 지원서 합/불 관리자 페이지를 위한 지원서 합/불 조회 기능 추가
- InterviewerController에서 필요없는 parameter Swagger에서 안보이도록 수정

### 변경로직
```java
private List<Map<String, Object>> sortAndAddIds(List<MongoAnswer> result, String sortType) {
        sortHelper.sort(result, sortType);
        List<Map<String, Object>> sortedResult = result.stream().map(MongoAnswer::getQna).toList();
        sortedResult.forEach(
                map -> {
                    map.put("id", result.get(sortedResult.indexOf(map)).getId());
                    map.put(PASS_STATE_KEY, result.get(sortedResult.indexOf(map)).getApplicantStateOrDefault());
                });
        return sortedResult;
    }
``` 

위의 로직이 반복으로 사용되고 있어서 sortAndAddIds로 모듈화시킴

### reference

- 