### PR TITLE
[BE-94] 지원서 합/불 관리페이지 응답 오류 수정

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
@@ -1,5 +1,7 @@
 package com.econovation.recruit.api.applicant.dto;
 
+import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
+import com.econovation.recruitdomain.domains.applicant.exception.ApplicantWrongStateException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,23 +14,29 @@ import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
 @AllArgsConstructor
 @Builder
 public class GetApplicantsStatusResponse {
+    private String field;
     private String field1;
     private String field2;
-    private String field3;
     private String name;
     private String id;
     private Integer year;
-    private String state;
+    private ApplicantState state;
 
-    public static GetApplicantsStatusResponse of(Map<String,Object> result) {
+    public static GetApplicantsStatusResponse of(Map<String, Object> result) {
+        ApplicantState state;
+        if (result.get(PASS_STATE_KEY) instanceof ApplicantState applicantState) {
+            state = applicantState;
+        } else {
+            throw ApplicantWrongStateException.wrongStatusException;
+        }
         return GetApplicantsStatusResponse.builder()
+                .field((String) result.get("field"))
                 .field1((String) result.get("field1"))
                 .field2((String) result.get("field2"))
-                .field3((String) result.get("field3"))
                 .name((String) result.get("name"))
                 .id((String) result.get("id"))
                 .year((Integer) result.get("year"))
-                .state(result.get(PASS_STATE_KEY).toString())
+                .state(state)
                 .build();
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
@@ -23,20 +23,17 @@ public class GetApplicantsStatusResponse {
     private ApplicantState state;
 
     public static GetApplicantsStatusResponse of(Map<String, Object> result) {
-        ApplicantState state;
         if (result.get(PASS_STATE_KEY) instanceof ApplicantState applicantState) {
-            state = applicantState;
-        } else {
-            throw ApplicantWrongStateException.wrongStatusException;
+            return GetApplicantsStatusResponse.builder()
+                    .field((String) result.get("field"))
+                    .field1((String) result.get("field1"))
+                    .field2((String) result.get("field2"))
+                    .name((String) result.get("name"))
+                    .id((String) result.get("id"))
+                    .year((Integer) result.get("year"))
+                    .state(applicantState)
+                    .build();
         }
-        return GetApplicantsStatusResponse.builder()
-                .field((String) result.get("field"))
-                .field1((String) result.get("field1"))
-                .field2((String) result.get("field2"))
-                .name((String) result.get("name"))
-                .id((String) result.get("id"))
-                .year((Integer) result.get("year"))
-                .state(state)
-                .build();
+        throw ApplicantWrongStateException.wrongStatusException;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/handler/ApplicantStateUpdateEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/handler/ApplicantStateUpdateEventHandler.java
@@ -25,8 +25,7 @@ public class ApplicantStateUpdateEventHandler {
     public String handle(ApplicantStateModifyEvent event){
         MongoAnswer answer = answerAdaptor.findById(event.getApplicantId()).get();
         ApplicantStateEvents command = event.getEvent();
-        boolean result = answer.stateEmptyCheckAndInit();
-        log.error(String.format("validate : %s", (result ? "새로운 state 초기화" : "state 초기화 하지 않고 변경")));
+        answer.stateEmptyCheckAndInit();
         switch (command) {
             case PASS:
                 answer.pass(periodCalculator.execute());

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -183,12 +183,12 @@ public class ApplicantService implements ApplicantQueryUseCase {
 
     private List<Map<String, Object>> sortAndAddIds(List<MongoAnswer> result, String sortType) {
         sortHelper.sort(result, sortType);
-        List<Map<String, Object>> sortedResult = result.stream().map(MongoAnswer::getQna).toList();
-        sortedResult.forEach(
-                map -> {
-                    map.put("id", result.get(sortedResult.indexOf(map)).getId());
-                    map.put(PASS_STATE_KEY, result.get(sortedResult.indexOf(map)).getApplicantStateOrDefault());
-                });
-        return sortedResult;
+        return result.stream().map(
+                answer -> {
+                    Map<String, Object> qna = answer.getQna();
+                    qna.put("id", answer.getId());
+                    qna.put(PASS_STATE_KEY, answer.getApplicantStateOrDefault());
+                    return qna;
+                }).toList();
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -6,6 +6,8 @@ import com.econovation.recruitcommon.annotation.Adaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerRepository;
 import java.util.List;
+
+import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -48,7 +50,11 @@ public class AnswerAdaptor {
         Query query =
                 new Query()
                         .addCriteria(Criteria.where("year").is(year));
-        return mongoTemplate.find(query, MongoAnswer.class);
+        List<MongoAnswer> result =  mongoTemplate.find(query, MongoAnswer.class);
+        if(result.isEmpty()) {
+            throw ApplicantNotFoundException.EXCEPTION;
+        }
+        return result;
     }
 
     public long getTotalCountByYear(Integer year) {


### PR DESCRIPTION
### 개요
close #258 

###  작업사항
- 지원서 합/불 관리페이지 응답 오류 수정

### 변경로직
```java
  public static GetApplicantsStatusResponse of(Map<String, Object> result) {
        ApplicantState state;
        if (result.get(PASS_STATE_KEY) instanceof ApplicantState applicantState) {
            state = applicantState;
        } else {
            throw ApplicantWrongStateException.wrongStatusException;
        }
        return GetApplicantsStatusResponse.builder()
                .field((String) result.get("field"))
                .field1((String) result.get("field1"))
                .field2((String) result.get("field2"))
                .name((String) result.get("name"))
                .id((String) result.get("id"))
                .year((Integer) result.get("year"))
                .state(state)
                .build();
    }
``` 

- field3은 존재하지 않아 null로 반환되던 오류 수정
- state는 아래와 같은 형식으로 응답되도록 수정
```java
state : {
  passState : string
}
``` 

### reference

- 