### PR TITLE
[BE-95] 면접 기록 조회 응답에 지원자의 합/불 상태를 나타내는 state 필드 추가

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/RecordViewResponseDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/RecordViewResponseDto.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.record.dto;
 
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
 import com.econovation.recruitdomain.domains.record.domain.Record;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -18,6 +19,7 @@ public class RecordViewResponseDto {
     private String grade;
     private String semester;
     private String modifiedAt;
+    private ApplicantState state;
 
     public static RecordViewResponseDto from(Record recordVo, Double score, MongoAnswer applicant) {
         String name =
@@ -35,6 +37,7 @@ public class RecordViewResponseDto {
                 applicant.getQna().get("field2").toString(),
                 applicant.getQna().get("grade").toString(),
                 applicant.getQna().get("semester").toString(),
-                recordVo.getUpdatedAt().toString());
+                recordVo.getUpdatedAt().toString(),
+                applicant.getApplicantState());
     }
 }


### PR DESCRIPTION
### 개요
close #258 

###  작업사항
- 면접 기록 페이지의 응답인, RecordResponseDto 클래스에 state 필드를 추가하였습니다.

### 변경로직
```java
@Data
@AllArgsConstructor
public class RecordViewResponseDto {
    private String applicantId;
    private Double scores;
    private String name;
    private String url;
    private String record;
    private String field1;
    private String field2;
    private String grade;
    private String semester;
    private String modifiedAt;
    private ApplicantState state;

    public static RecordViewResponseDto from(Record recordVo, Double score, MongoAnswer applicant) {
        String name =
                "["
                        + applicant.getQna().get("field").toString()
                        + "] "
                        + applicant.getQna().get("name").toString();
        return new RecordViewResponseDto(
                recordVo.getApplicantId(),
                score,
                name,
                recordVo.getUrl(),
                recordVo.getRecord(),
                applicant.getQna().get("field1").toString(),
                applicant.getQna().get("field2").toString(),
                applicant.getQna().get("grade").toString(),
                applicant.getQna().get("semester").toString(),
                recordVo.getUpdatedAt().toString(),
                applicant.getApplicantState());
    }
}
```


### reference

- 