### PR TITLE
[BE-109] 개발 서버 도메인 CORS 허용

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/CorsConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/CorsConfig.java
@@ -16,6 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         ArrayList<String> allowedOriginPatterns = new ArrayList<>();
         allowedOriginPatterns.add("https://recruit.econovation.kr");
+        allowedOriginPatterns.add("https://recruit-develop.econovation.kr");
         allowedOriginPatterns.add("https://auth.econovation.kr");
         if (!springEnvironmentHelper.isProdProfile()) {
             allowedOriginPatterns.add("http://localhost:3000");


### PR DESCRIPTION
### 개요
close #289 

###  작업사항
- 개발 서버도 도메인으로 관리하기 위해 `Cloudflare` 에 A 레코드를 추가했습니다.
  - `recruit-develop.econovation.kr`

- 위 도메인의 CORS 허용을 위해 `addCorsMappings` 메서드에서 주소를 추가했습니다.
