### PR TITLE
[BE-114] spotless 버전 6.11.0 -> 6.22.0 Upgrade

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.7'
-    id 'com.diffplug.spotless' version '6.11.0'
+    id 'com.diffplug.spotless' version '6.22.0'
     id "org.sonarqube" version "4.4.1.3373"
 }
 


### PR DESCRIPTION
### 개요
close #315 

###  작업사항
- `build.gradle` spotless plugin 버전 6.11.0에서 6.22.0 변경

### 변경로직
```gradle
plugins {
    id 'java'
    id 'org.springframework.boot' version '2.7.7'
    id 'com.diffplug.spotless' version '6.22.0'
    id "org.sonarqube" version "4.4.1.3373"
}
```


### reference

- 