### PR TITLE
[BE-115] String으로 관리하던 html 폼을 분리하여 관리

### DIFF
--- a/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/apache/CommonsEmailSender.java
+++ b/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/apache/CommonsEmailSender.java
@@ -11,12 +11,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class CommonsEmailSender {
     private final CommonsEmailProperties commonsEmailProperties;
+    private final TemplateEngine htmlTemplateEngine;
 
     @Value("${econovation.year}")
     private Integer year;
@@ -125,16 +128,14 @@ public class CommonsEmailSender {
         }
     }
 
-    private String generateHtml(String applicantId, LocalDateTime passedDate) {
-        String html =
-                "<!DOCTYPE html><html lang=\"ko\"><head> <meta charset=\"utf-8\"> <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"> <title>Econovation Recruit</title> <meta name=\"description\" content=\"Recruit site for econovation\"> <style>.hover-a{text-decoration: none;} .hover-a:hover{text-decoration: underline;}</style></head><body style=\"width:fit-content; height: 100vh; max-width: 1920px; margin: auto; display: block; text-align: center;\"> <section style=\"padding-top: 100px;\"><img alt=\"econo-3d-logo\" width=\"114\" height=\"143\" style=\"color:transparent; margin:auto;\" src=\"https://recruit.econovation.kr/images/econo-3d-logo.png\"> <h1 style=\"font-weight: 800; font-size:40px;\">신입모집 지원 완료!</h1> <div style=\"font-size: 18px;\"> <div style=\"margin: 8px;\">에코노베이션 %YEAR%기 지원서가 정상적으로 업로드 되었습니다</div> <div style=\"margin: 8px;\">서류 합격 결과는 %PASSED_DATE%에 개인 메일으로 공지 될 예정입니다.</div> <div style=\"margin: 8px;\"><a class=\"hover-a\" style=\"color: #2160FF; font-weight: 700;\" href=\"https://%DOMAIN%/applicant/pdf-viewer?id=%APPLICANT_ID%\">여기</a>에서 지원서를 확인하실 수 있습니다.</div> <div style=\"margin: 8px;\">지원해주셔서 감사합니다.</div> </div> </section></body></html>";
-        return html.replace("%YEAR%", year.toString())
-                .replace("%DOMAIN%", domain)
-                .replace(
-                        "%PASSED_DATE%",
-                        passedDate
-                                .format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 / HH:mm:ss"))
-                                .toString())
-                .replace("%APPLICANT_ID%", applicantId);
+    public String generateHtml(String applicantId, LocalDateTime passedDate) {
+        Context context = new Context();
+        context.setVariable("year", year.toString());
+        context.setVariable("domain", domain);
+        context.setVariable(
+                "passedDate",
+                passedDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 / HH:mm:ss")));
+        context.setVariable("applicantId", applicantId);
+        return htmlTemplateEngine.process("email-form", context);
     }
 }

--- a/server/Recruit-Infrastructure/src/main/resources/templates/email-form.html
+++ b/server/Recruit-Infrastructure/src/main/resources/templates/email-form.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Econovation Recruit</title>
+    <meta name="description" content="Recruit site for econovation">
+    <style>
+        .hover-a{text-decoration: none;}
+        .hover-a:hover{text-decoration: underline;}
+    </style>
+</head>
+<body style="width:fit-content; height: 100vh; max-width: 1920px; margin: auto; display: block; text-align: center;">
+<section style="padding-top: 100px;">
+    <img alt="econo-3d-logo" width="114" height="143" style="color:transparent; margin:auto;" src="https://recruit.econovation.kr/images/econo-3d-logo.png">
+    <h1 style="font-weight: 800; font-size:40px;">신입모집 지원 완료!</h1>
+    <div style="font-size: 18px;">
+        <div style="margin: 8px;">에코노베이션 <span th:text="${year}"></span>기 지원서가 정상적으로 업로드 되었습니다</div>
+        <div style="margin: 8px;">서류 합격 결과는 <span th:text="${passedDate}"></span>에 개인 메일로 공지 될 예정입니다.</div>
+        <div style="margin: 8px;"><a class="hover-a" style="color: #2160FF; font-weight: 700;" th:href="@{'https://' + ${domain} + '/applicant/pdf-viewer?id=' + ${applicantId}}">여기</a>에서 지원서를 확인하실 수 있습니다.</div>
+        <div style="margin: 8px;">지원해주셔서 감사합니다.</div>
+    </div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
### 개요
close #317 

###  작업사항
- 기존에 String으로 관리하던 html 폼을 resources/templates 폴더에 html 파일로 분리했습니다.
- 기존 generateHtml 메서드를 템플릿 엔진 타임리프를 사용하여 리팩토링하였습니다.
- 따로 TestController를 만들어서 Model 객체로 값을 바인딩하여 html 파일이 문제 없는지 확인하고 generateHtml 메서드의 동작을 테스트하였습니다. 

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ff1e682d-7b50-4ea6-9158-01388994c1af" />

정상적으로 렌더링 되는 것과 파란색 글자 "여기"를 클릭하면 설정한 도메인 주소로 이동하는 것을 확인하였습니다. 

### 변경로직
- 리팩토링 과정에서 html 파일을 분리하고 타임리프를 적용한 것 외에는 변경로직은 없습니다. 


### reference

- https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/107 주차권 프로젝트를 참고하였습니다. 