### PR TITLE
[BE-121] 지원서 backup 실패 오류를 해결합니다.

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
@@ -73,7 +73,6 @@ public class AnswerCreatedEventListener {
             file.close();
         } catch (IOException e) {
             log.error("applicantId : " + event.getId() + " / " + qna.toString() + " backup fail");
-            e.printStackTrace();
         }
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
@@ -8,6 +8,7 @@ import com.econovation.recruitdomain.domains.applicant.event.domainevent.Applica
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +61,11 @@ public class AnswerCreatedEventListener {
         try {
             String path = new File(".").getCanonicalPath(); // 현재 작업 디렉토리를 가져옴
             String backupDir = path + "/backup/";
+
+            if (!Files.exists(new File(backupDir).toPath())) {
+                Files.createDirectories(new File(backupDir).toPath());
+            }
+
             JSONObject jsonObject = new JSONObject(qna);
             FileWriter file = new FileWriter(backupDir + event.getId() + ".json");
             file.write(jsonObject.toJSONString());
@@ -67,6 +73,7 @@ public class AnswerCreatedEventListener {
             file.close();
         } catch (IOException e) {
             log.error("applicantId : " + event.getId() + " / " + qna.toString() + " backup fail");
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
### 개요
close #326 

###  작업사항
- 지원자가 지원서 접수 시, backup 로직이 실패합니다. 현재 로직은 backup 디렉터리가 존재하는지 존재하지 않는지 검증하고 있지 않습니다.
   backup 디렉터리가 존재하지 않을 경우, backup 작업이 실패하므로 backup 디렉터리를 생성합니다.

### 변경로직
- backup 디렉터리가 존재하지 않을 경우 backup 디렉터리를 생성하도록 수정했습니다.


### reference

- 