### PR TITLE
[BE-122] 이메일 발송 이벤트 처리를 수정합니다.

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/handler/EmailSendEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/handler/EmailSendEventHandler.java
@@ -22,7 +22,6 @@ public class EmailSendEventHandler {
     @TransactionalEventListener(
             classes = EmailSendEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EmailSendEvent emailSendEvent) {
         String applicantId = emailSendEvent.getApplicantId();
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/handler/EmailSendEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/handler/EmailSendEventHandler.java
@@ -4,12 +4,9 @@ import com.econovation.recruit.api.sms.service.ApplicantSmsService;
 import com.econovation.recruitdomain.domains.email_template.event.EmailSendEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -19,9 +16,7 @@ public class EmailSendEventHandler {
     private final ApplicantSmsService smsService;
 
     @Async
-    @TransactionalEventListener(
-            classes = EmailSendEvent.class,
-            phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener(EmailSendEvent.class)
     public void handle(EmailSendEvent emailSendEvent) {
         String applicantId = emailSendEvent.getApplicantId();
 


### PR DESCRIPTION
### 개요
close #328 

###  작업사항
- 이메일 발송 성공 이벤트 발행시 병목 현상이 발생하여, Database Connection Timeout이 발생하고 있습니다.
- 트랜잭션 구조를 변경하고, 아래와 같이 구조를 변경합니다.
  -  이메일 발송 성공 이벤트 핸들러에 `@Transactional` 을 사용하지 않습니다.
  -  이메일 발송 성공 이벤트 핸들러에 `@TransactionalEventListener` 를 사용하지 않고, `@EventListener`를 사용합니다.

### 변경로직

### reference

- 