### PR TITLE
[BE-125] 불필요 필드 제거된 신입 면접 기록 목록 API 추가

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
@@ -6,6 +6,7 @@ import static com.econovation.recruitcommon.consts.RecruitStatic.RECORD_SUCCESS_
 import com.econovation.recruit.api.record.docs.RecordCreateExceptionDocs;
 import com.econovation.recruit.api.record.docs.RecordFindExceptionDocs;
 import com.econovation.recruit.api.record.dto.RecordsViewResponseDto;
+import com.econovation.recruit.api.record.dto.SimpleRecordsViewResponseDto;
 import com.econovation.recruit.api.record.usecase.RecordUseCase;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitdomain.domains.dto.CreateRecordDto;
@@ -29,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/")
+@RequestMapping("/api/v1")
 @Tag(name = "[6.0] Record API", description = "면접 기록 Record API")
 @RequiredArgsConstructor
 public class RecordController {
@@ -56,6 +57,7 @@ public class RecordController {
             description = "newest, name, object, score 이 4가지중 하나를 입력하시면 됩니다.")
     @ApiErrorExceptionsExample(RecordFindExceptionDocs.class)
     @GetMapping("/page/{page}/records")
+    @Deprecated(since = "2025-05-29", forRemoval = true)
     public ResponseEntity<RecordsViewResponseDto> findAll(
             @PathVariable(name = "page") Integer page,
             @ParameterObject String order,
@@ -64,6 +66,21 @@ public class RecordController {
         return new ResponseEntity<>(
                 recordUseCase.execute(page, year, order, searchKeyword), HttpStatus.OK);
     }
+
+    @Operation(
+            summary = "지원자의 면접기록 목록을 페이지 및 기수별로 조회합니다",
+            description = "newest, name, object, score 이 4가지중 하나를 입력하시면 됩니다.")
+    @ApiErrorExceptionsExample(RecordFindExceptionDocs.class)
+    @GetMapping("/page/{page}/year/{year}/records")
+    public ResponseEntity<SimpleRecordsViewResponseDto> findAllSimpleByYear(
+            @PathVariable(name = "page") Integer page,
+            @PathVariable(name = "year") Integer year,
+            @ParameterObject String order,
+            @RequestParam(required = false) String searchKeyword) {
+        return new ResponseEntity<>(
+                recordUseCase.executeSimple(page, year, order, searchKeyword), HttpStatus.OK);
+    }
+
 
     @Operation(summary = "지원자의 면접기록을 전부 조회합니다")
     @ApiErrorExceptionsExample(RecordFindExceptionDocs.class)

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/FilteredRecordsApplicantsDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/FilteredRecordsApplicantsDto.java
@@ -1,0 +1,16 @@
+package com.econovation.recruit.api.record.dto;
+
+import com.econovation.recruit.utils.vo.PageInfo;
+import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.record.domain.Record;
+import java.util.List;
+import java.util.Map;
+
+public record FilteredRecordsApplicantsDto(
+        List<Record> records,
+        List<MongoAnswer> applicants,
+        Map<String, Double> scoreMap,
+        PageInfo pageInfo
+) {
+
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordViewResponseDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordViewResponseDto.java
@@ -1,0 +1,35 @@
+package com.econovation.recruit.api.record.dto;
+
+import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
+import com.econovation.recruitdomain.domains.record.domain.Record;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SimpleRecordViewResponseDto {
+    private String applicantId;
+    private String name;
+    private String field1;
+    private String field2;
+    private String grade;
+    private String semester;
+    private ApplicantState state;
+
+    public static SimpleRecordViewResponseDto from(Record recordVo, MongoAnswer applicant) {
+        String name =
+                "["
+                        + applicant.getQna().get("field").toString()
+                        + "] "
+                        + applicant.getQna().get("name").toString();
+        return new SimpleRecordViewResponseDto(
+                recordVo.getApplicantId(),
+                name,
+                applicant.getQna().get("field1").toString(),
+                applicant.getQna().get("field2").toString(),
+                applicant.getQna().get("grade").toString(),
+                applicant.getQna().get("semester").toString(),
+                applicant.getApplicantState());
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordsViewResponseDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordsViewResponseDto.java
@@ -1,0 +1,49 @@
+package com.econovation.recruit.api.record.dto;
+
+import com.econovation.recruit.utils.vo.PageInfo;
+import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.record.domain.Record;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SimpleRecordsViewResponseDto {
+    private List<SimpleRecordViewResponseDto> records;
+    private PageInfo pageInfo;
+
+    public static SimpleRecordsViewResponseDto of(
+            PageInfo pageInfo,
+            List<Record> records,
+            List<MongoAnswer> applicants) {
+        List<SimpleRecordViewResponseDto> simpleRecordViewResponseDtos =
+                records.stream()
+                        .map(
+                                record -> {
+                                    MongoAnswer applicant =
+                                            applicants.stream()
+                                                    .filter(
+                                                            a ->
+                                                                    a.getId()
+                                                                            .equals(
+                                                                                    record
+                                                                                            .getApplicantId()))
+                                                    .findFirst()
+                                                    .get();
+                                    return SimpleRecordViewResponseDto.from(record, applicant);
+                                })
+                        .toList();
+        return SimpleRecordsViewResponseDto.builder()
+                .pageInfo(pageInfo)
+                .records(simpleRecordViewResponseDtos)
+                .build();
+    }
+
+    public static SimpleRecordsViewResponseDto empty(PageInfo pageInfo) {
+        return SimpleRecordsViewResponseDto.builder().pageInfo(pageInfo).records(List.of()).build();
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
@@ -5,6 +5,7 @@ import static com.econovation.recruit.utils.sort.SortHelper.paginateList;
 import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
 import com.econovation.recruit.api.record.dto.FilteredRecordsWithScoresDto;
 import com.econovation.recruit.api.record.dto.RecordsViewResponseDto;
+import com.econovation.recruit.api.record.dto.SimpleRecordsViewResponseDto;
 import com.econovation.recruit.api.record.usecase.RecordUseCase;
 import com.econovation.recruit.utils.sort.SortHelper;
 import com.econovation.recruit.utils.vo.PageInfo;
@@ -132,6 +133,38 @@ public class RecordService implements RecordUseCase {
 
         PageInfo pageInfo = applicantQueryUseCase.getPageInfo(year, page, searchKeyword);
         return RecordsViewResponseDto.of(pageInfo, records, filteredData.scoreMap(), applicants);
+    }
+
+    @Override
+    public SimpleRecordsViewResponseDto executeSimple(
+            Integer page, Integer year, String sortType, String searchKeyword) {
+        List<Record> result = recordLoadPort.findAll();
+        List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
+
+        List<MongoAnswer> applicants;
+        List<Record> records;
+        FilteredRecordsWithScoresDto filteredData;
+
+        if (sortType.equals("score")) {
+            applicants = applicantQueryUseCase.execute(year, sortType, searchKeyword, applicantIds);
+            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
+            records =
+                    sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
+        } else {
+            applicants =
+                    applicantQueryUseCase.execute(
+                            page, year, sortType, searchKeyword, applicantIds);
+            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
+            records = sortRecordsByApplicantsAndSortType(filteredData.records(), applicants);
+        }
+
+        if (result.isEmpty() || applicants.isEmpty()) {
+            return SimpleRecordsViewResponseDto.empty(new PageInfo(0, page));
+        }
+
+        PageInfo pageInfo = applicantQueryUseCase.getPageInfo(year, page, searchKeyword);
+        return SimpleRecordsViewResponseDto.of(
+                pageInfo, records, applicants);
     }
 
     private FilteredRecordsWithScoresDto filterRecordsAndCalculateScores(

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
@@ -3,6 +3,7 @@ package com.econovation.recruit.api.record.service;
 import static com.econovation.recruit.utils.sort.SortHelper.paginateList;
 
 import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
+import com.econovation.recruit.api.record.dto.FilteredRecordsApplicantsDto;
 import com.econovation.recruit.api.record.dto.FilteredRecordsWithScoresDto;
 import com.econovation.recruit.api.record.dto.RecordsViewResponseDto;
 import com.econovation.recruit.api.record.dto.SimpleRecordsViewResponseDto;
@@ -107,64 +108,56 @@ public class RecordService implements RecordUseCase {
     @Override
     public RecordsViewResponseDto execute(
             Integer page, Integer year, String sortType, String searchKeyword) {
-        List<Record> result = recordLoadPort.findAll();
-        List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
-
-        List<MongoAnswer> applicants;
-        List<Record> records;
-        FilteredRecordsWithScoresDto filteredData;
-
-        if (sortType.equals("score")) {
-            applicants = applicantQueryUseCase.execute(year, sortType, searchKeyword, applicantIds);
-            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
-            records =
-                    sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
-        } else {
-            applicants =
-                    applicantQueryUseCase.execute(
-                            page, year, sortType, searchKeyword, applicantIds);
-            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
-            records = sortRecordsByApplicantsAndSortType(filteredData.records(), applicants);
+        FilteredRecordsApplicantsDto filteredRecordsApplicant =
+                filterRecordsAndGetApplicants(page, year, sortType, searchKeyword);
+        if (filteredRecordsApplicant.records().isEmpty() || filteredRecordsApplicant.applicants().isEmpty()) {
+            return RecordsViewResponseDto.empty(filteredRecordsApplicant.pageInfo());
         }
-
-        if (result.isEmpty() || applicants.isEmpty()) {
-            return RecordsViewResponseDto.empty(new PageInfo(0, page));
-        }
-
-        PageInfo pageInfo = applicantQueryUseCase.getPageInfo(year, page, searchKeyword);
-        return RecordsViewResponseDto.of(pageInfo, records, filteredData.scoreMap(), applicants);
+        return RecordsViewResponseDto.of(
+                filteredRecordsApplicant.pageInfo(),
+                filteredRecordsApplicant.records(),
+                filteredRecordsApplicant.scoreMap(),
+                filteredRecordsApplicant.applicants()
+        );
     }
 
     @Override
     public SimpleRecordsViewResponseDto executeSimple(
+            Integer page, Integer year, String sortType, String searchKeyword) {
+        FilteredRecordsApplicantsDto filteredRecordsApplicant = filterRecordsAndGetApplicants(page, year, sortType, searchKeyword);
+        if (filteredRecordsApplicant.records().isEmpty() || filteredRecordsApplicant.applicants().isEmpty()) {
+            return SimpleRecordsViewResponseDto.empty(filteredRecordsApplicant.pageInfo());
+        }
+        return SimpleRecordsViewResponseDto.of(
+                filteredRecordsApplicant.pageInfo(),
+                filteredRecordsApplicant.records(),
+                filteredRecordsApplicant.applicants()
+        );
+    }
+
+    private FilteredRecordsApplicantsDto filterRecordsAndGetApplicants(
             Integer page, Integer year, String sortType, String searchKeyword) {
         List<Record> result = recordLoadPort.findAll();
         List<String> applicantIds = result.stream().map(Record::getApplicantId).toList();
 
         List<MongoAnswer> applicants;
         List<Record> records;
-        FilteredRecordsWithScoresDto filteredData;
+        Map<String, Double> scoreMap;
 
         if (sortType.equals("score")) {
             applicants = applicantQueryUseCase.execute(year, sortType, searchKeyword, applicantIds);
-            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
-            records =
-                    sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
+            FilteredRecordsWithScoresDto filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
+            records = sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
+            scoreMap = filteredData.scoreMap();
         } else {
-            applicants =
-                    applicantQueryUseCase.execute(
-                            page, year, sortType, searchKeyword, applicantIds);
-            filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
+            applicants = applicantQueryUseCase.execute(page, year, sortType, searchKeyword, applicantIds);
+            FilteredRecordsWithScoresDto filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
             records = sortRecordsByApplicantsAndSortType(filteredData.records(), applicants);
-        }
-
-        if (result.isEmpty() || applicants.isEmpty()) {
-            return SimpleRecordsViewResponseDto.empty(new PageInfo(0, page));
+            scoreMap = filteredData.scoreMap();
         }
 
         PageInfo pageInfo = applicantQueryUseCase.getPageInfo(year, page, searchKeyword);
-        return SimpleRecordsViewResponseDto.of(
-                pageInfo, records, applicants);
+        return new FilteredRecordsApplicantsDto(records, applicants, scoreMap, pageInfo);
     }
 
     private FilteredRecordsWithScoresDto filterRecordsAndCalculateScores(

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/usecase/RecordUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/usecase/RecordUseCase.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.record.usecase;
 
 import com.econovation.recruit.api.record.dto.RecordsViewResponseDto;
+import com.econovation.recruit.api.record.dto.SimpleRecordsViewResponseDto;
 import com.econovation.recruitdomain.domains.dto.CreateRecordDto;
 import com.econovation.recruitdomain.domains.dto.UpdateRecordDto;
 import com.econovation.recruitdomain.domains.record.domain.Record;
@@ -14,6 +15,9 @@ public interface RecordUseCase {
     RecordsViewResponseDto execute(Integer page, Integer year, String sortType);
 
     RecordsViewResponseDto execute(
+            Integer page, Integer year, String sortType, String searchKeyword);
+
+    SimpleRecordsViewResponseDto executeSimple(
             Integer page, Integer year, String sortType, String searchKeyword);
 
     Record findByApplicantId(String applicantId);


### PR DESCRIPTION
### 개요
close #337 

###  작업사항
- `record`, `url`, `scores`, `modifiedAt` 필드를 제거한 `SimpleRecordViewResponseDto` 추가
- `SimpleRecordViewResponseDto` 리스트 및 페이지 정보를 보여 줄 `SimpleRecordsViewResponseDto` 추가
- `RecordUseCase`에 `executeSimple` 추가
- `RecordService`에 `executeSimple` 구현
- `RecordController`에 `/api/v1/page/{page}/year/{year}/records` 엔드포인트 추가

### 변경로직
- year를 PathVariable로 받으며, 간소화된 면접 기록 목록을 조회하는 API 추가


### reference
- 간소화한 목록을 보여주기 위해 SImple 접두사가 붙은 DTO를 새로 생성하였습니다.
- 면접 기록 목록을 보여주는 엔드포인트는 v2가 아닌 v1을 사용하였는데, year를 PathVariable로 변경 및 간소화된 값을 넘겨주는 새로운 엔드포인트 추가로 판단해 v1을 유지했습니다.
- `RecordService`의 `execute`와 `executeSimple`의 경우 약 17줄의 중복 코드가 발생합니다. `execute`는 Deprecated 된 엔드포인트에 포함된 함수로 해당 작업이 완료되면 사라질 것으로 생각해 중복 코드를 허용하였습니다. 이를 함수화 시키는 방향에 대해서는어떻게 생각하는지 의견 부탁드립니다.