### PR TITLE
[BE-129] 비밀번호 재설정 기능 구현

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -162,10 +162,10 @@ public class ApplicantController {
 
     @Operation(
             summary = "지원서의 합/불 상태를 조회합니다. (합/불 관리자 페이지 전용)",
-            description = """
-                    응답으로 오는 passState 값의 종류는 non-processed, non-passed, first-passed, final-passed 입니다.
+            description =
                     """
-    )
+                    응답으로 오는 passState 값의 종류는 non-processed, non-passed, first-passed, final-passed 입니다.
+                    """)
     @GetMapping("year/{year}/applicants/pass-state")
     public ResponseEntity<List<GetApplicantsStatusResponse>> getApplicantsStatus(
             @PathVariable("year") Integer year, @RequestParam("order") String sortType) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/FilterConfig.java
@@ -22,7 +22,8 @@ public class FilterConfig
     @Override
     public void configure(HttpSecurity builder) {
         builder.addFilterBefore(
-                new JwtTokenFilter(jwtTokenProvider, whitelistLoadPort), BasicAuthenticationFilter.class);
+                new JwtTokenFilter(jwtTokenProvider, whitelistLoadPort),
+                BasicAuthenticationFilter.class);
         builder.addFilterBefore(jwtExceptionFilter, JwtTokenFilter.class);
         //        builder.addFilterBefore(accessDeniedFilter, FilterSecurityInterceptor.class);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -123,7 +123,8 @@ public class SecurityConfig {
                                 "/api/v1/login",
                                 "/api/v1/register",
                                 "/api/v1/password/reset",
-                                "/api/v1/send-email")
+                                "/api/v1/send-email",
+                                "/api/v1/verify-code")
                         .antMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/applicants",

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -121,7 +121,8 @@ public class SecurityConfig {
                                 "/api/v1/signup",
                                 "/api/v1/token/refresh",
                                 "/api/v1/login",
-                                "/api/v1/register")
+                                "/api/v1/register",
+                                "/api/v1/password/reset")
                         .antMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/applicants",

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -122,7 +122,8 @@ public class SecurityConfig {
                                 "/api/v1/token/refresh",
                                 "/api/v1/login",
                                 "/api/v1/register",
-                                "/api/v1/password/reset")
+                                "/api/v1/password/reset",
+                                "/api/v1/send-email")
                         .antMatchers(
                                 HttpMethod.GET,
                                 "/api/v1/applicants",

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/controller/RecordController.java
@@ -81,7 +81,6 @@ public class RecordController {
                 recordUseCase.executeSimple(page, year, order, searchKeyword), HttpStatus.OK);
     }
 
-
     @Operation(summary = "지원자의 면접기록을 전부 조회합니다")
     @ApiErrorExceptionsExample(RecordFindExceptionDocs.class)
     @GetMapping("/records/all")

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/FilteredRecordsApplicantsDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/FilteredRecordsApplicantsDto.java
@@ -10,7 +10,4 @@ public record FilteredRecordsApplicantsDto(
         List<Record> records,
         List<MongoAnswer> applicants,
         Map<String, Double> scoreMap,
-        PageInfo pageInfo
-) {
-
-}
+        PageInfo pageInfo) {}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordsViewResponseDto.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/dto/SimpleRecordsViewResponseDto.java
@@ -4,7 +4,6 @@ import com.econovation.recruit.utils.vo.PageInfo;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.record.domain.Record;
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,9 +16,7 @@ public class SimpleRecordsViewResponseDto {
     private PageInfo pageInfo;
 
     public static SimpleRecordsViewResponseDto of(
-            PageInfo pageInfo,
-            List<Record> records,
-            List<MongoAnswer> applicants) {
+            PageInfo pageInfo, List<Record> records, List<MongoAnswer> applicants) {
         List<SimpleRecordViewResponseDto> simpleRecordViewResponseDtos =
                 records.stream()
                         .map(

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/record/service/RecordService.java
@@ -110,29 +110,30 @@ public class RecordService implements RecordUseCase {
             Integer page, Integer year, String sortType, String searchKeyword) {
         FilteredRecordsApplicantsDto filteredRecordsApplicant =
                 filterRecordsAndGetApplicants(page, year, sortType, searchKeyword);
-        if (filteredRecordsApplicant.records().isEmpty() || filteredRecordsApplicant.applicants().isEmpty()) {
+        if (filteredRecordsApplicant.records().isEmpty()
+                || filteredRecordsApplicant.applicants().isEmpty()) {
             return RecordsViewResponseDto.empty(filteredRecordsApplicant.pageInfo());
         }
         return RecordsViewResponseDto.of(
                 filteredRecordsApplicant.pageInfo(),
                 filteredRecordsApplicant.records(),
                 filteredRecordsApplicant.scoreMap(),
-                filteredRecordsApplicant.applicants()
-        );
+                filteredRecordsApplicant.applicants());
     }
 
     @Override
     public SimpleRecordsViewResponseDto executeSimple(
             Integer page, Integer year, String sortType, String searchKeyword) {
-        FilteredRecordsApplicantsDto filteredRecordsApplicant = filterRecordsAndGetApplicants(page, year, sortType, searchKeyword);
-        if (filteredRecordsApplicant.records().isEmpty() || filteredRecordsApplicant.applicants().isEmpty()) {
+        FilteredRecordsApplicantsDto filteredRecordsApplicant =
+                filterRecordsAndGetApplicants(page, year, sortType, searchKeyword);
+        if (filteredRecordsApplicant.records().isEmpty()
+                || filteredRecordsApplicant.applicants().isEmpty()) {
             return SimpleRecordsViewResponseDto.empty(filteredRecordsApplicant.pageInfo());
         }
         return SimpleRecordsViewResponseDto.of(
                 filteredRecordsApplicant.pageInfo(),
                 filteredRecordsApplicant.records(),
-                filteredRecordsApplicant.applicants()
-        );
+                filteredRecordsApplicant.applicants());
     }
 
     private FilteredRecordsApplicantsDto filterRecordsAndGetApplicants(
@@ -146,12 +147,17 @@ public class RecordService implements RecordUseCase {
 
         if (sortType.equals("score")) {
             applicants = applicantQueryUseCase.execute(year, sortType, searchKeyword, applicantIds);
-            FilteredRecordsWithScoresDto filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
-            records = sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
+            FilteredRecordsWithScoresDto filteredData =
+                    filterRecordsAndCalculateScores(result, applicants, year, page);
+            records =
+                    sortRecordsByScoresDesc(filteredData.records(), filteredData.scoreMap(), page);
             scoreMap = filteredData.scoreMap();
         } else {
-            applicants = applicantQueryUseCase.execute(page, year, sortType, searchKeyword, applicantIds);
-            FilteredRecordsWithScoresDto filteredData = filterRecordsAndCalculateScores(result, applicants, year, page);
+            applicants =
+                    applicantQueryUseCase.execute(
+                            page, year, sortType, searchKeyword, applicantIds);
+            FilteredRecordsWithScoresDto filteredData =
+                    filterRecordsAndCalculateScores(result, applicants, year, page);
             records = sortRecordsByApplicantsAndSortType(filteredData.records(), applicants);
             scoreMap = filteredData.scoreMap();
         }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -13,6 +13,7 @@ import com.econovation.recruitcommon.annotation.PasswordValidate;
 import com.econovation.recruitcommon.dto.TokenResponse;
 import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import com.econovation.recruitdomain.domains.dto.LoginRequestDto;
+import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import io.swagger.v3.oas.annotations.Operation;
@@ -94,6 +95,13 @@ public class UserController {
     public ResponseEntity<String> changePassword(
             @RequestParam @Valid @PasswordValidate String password) {
         userRegisterUseCase.changePassword(password);
+        return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "로그인을 위한 비밀번호를 재설정합니다.")
+    @PostMapping("/password/reset")
+    public ResponseEntity<String> resetPassword(@RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
+        userRegisterUseCase.resetPassword(resetPasswordRequestDto);
         return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -121,7 +121,8 @@ public class UserController {
 
     @Operation(summary = "인증코드 검증", description = "메일로 전송한 인증코드와 사용자가 입력한 인증코드가 일치하는지 확인합니다.")
     @PostMapping("/verify-code")
-    public ResponseEntity verifyCode(@Valid @RequestBody VerifyCodeRequestDto verifyCodeRequestDto) {
+    public ResponseEntity verifyCode(
+            @Valid @RequestBody VerifyCodeRequestDto verifyCodeRequestDto) {
         verifyCodeUseCase.verifyCode(verifyCodeRequestDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -100,7 +100,8 @@ public class UserController {
 
     @Operation(summary = "비밀번호 재설정", description = "로그인을 위한 비밀번호를 재설정합니다.")
     @PostMapping("/password/reset")
-    public ResponseEntity<String> resetPassword(@RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
+    public ResponseEntity<String> resetPassword(
+            @RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
         userRegisterUseCase.resetPassword(resetPasswordRequestDto);
         return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.econovation.recruit.api.user.usecase.SendEmailUseCase;
 import com.econovation.recruit.api.user.usecase.UserLoginUseCase;
 import com.econovation.recruit.api.user.usecase.UserLogoutUseCase;
 import com.econovation.recruit.api.user.usecase.UserRegisterUseCase;
+import com.econovation.recruit.api.user.usecase.VerifyCodeUseCase;
 import com.econovation.recruit.utils.SecurityUtils;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitcommon.annotation.DevelopOnlyApi;
@@ -17,6 +18,7 @@ import com.econovation.recruitdomain.domains.dto.LoginRequestDto;
 import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
 import com.econovation.recruitdomain.domains.dto.SendEmailRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
+import com.econovation.recruitdomain.domains.dto.VerifyCodeRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,6 +46,7 @@ public class UserController {
     private final UserLoginUseCase userLoginUseCase;
     private final UserLogoutUseCase userLogoutUseCase;
     private final SendEmailUseCase sendEmailUseCase;
+    private final VerifyCodeUseCase verifyCodeUseCase;
     private final Long tempId = 0L;
 
     @DevelopOnlyApi
@@ -113,6 +116,13 @@ public class UserController {
     @PostMapping("/send-email")
     public ResponseEntity sendEmail(@RequestBody SendEmailRequestDto sendEmailRequestDto) {
         sendEmailUseCase.sendEmail(sendEmailRequestDto);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "인증코드 검증", description = "메일로 전송한 인증코드와 사용자가 입력한 인증코드가 일치하는지 확인합니다.")
+    @PostMapping("/verify-code")
+    public ResponseEntity verifyCode(@Valid @RequestBody VerifyCodeRequestDto verifyCodeRequestDto) {
+        verifyCodeUseCase.verifyCode(verifyCodeRequestDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.econovation.recruit.api.user.controller;
 import static com.econovation.recruitcommon.consts.RecruitStatic.*;
 
 import com.econovation.recruit.api.interviewer.docs.InterviewerExceptionDocs;
+import com.econovation.recruit.api.user.usecase.SendEmailUseCase;
 import com.econovation.recruit.api.user.usecase.UserLoginUseCase;
 import com.econovation.recruit.api.user.usecase.UserLogoutUseCase;
 import com.econovation.recruit.api.user.usecase.UserRegisterUseCase;
@@ -14,6 +15,7 @@ import com.econovation.recruitcommon.dto.TokenResponse;
 import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import com.econovation.recruitdomain.domains.dto.LoginRequestDto;
 import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
+import com.econovation.recruitdomain.domains.dto.SendEmailRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,6 +43,7 @@ public class UserController {
     private final UserRegisterUseCase userRegisterUseCase;
     private final UserLoginUseCase userLoginUseCase;
     private final UserLogoutUseCase userLogoutUseCase;
+    private final SendEmailUseCase sendEmailUseCase;
     private final Long tempId = 0L;
 
     @DevelopOnlyApi
@@ -104,5 +107,12 @@ public class UserController {
             @RequestBody ResetPasswordRequestDto resetPasswordRequestDto) {
         userRegisterUseCase.resetPassword(resetPasswordRequestDto);
         return new ResponseEntity<>(PASSWORD_SUCCESS_CHANGE_MESSAGE, HttpStatus.OK);
+    }
+
+    @Operation(summary = "메일로 인증코드 발송", description = "메일로 인증코드를 발송합니다.")
+    @PostMapping("/send-email")
+    public ResponseEntity sendEmail(@RequestBody SendEmailRequestDto sendEmailRequestDto) {
+        sendEmailUseCase.sendEmail(sendEmailRequestDto);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
@@ -51,7 +51,10 @@ public class EmailVerificationService implements SendEmailUseCase, VerifyCodeUse
     @Override
     public void verifyCode(VerifyCodeRequestDto verifyCodeRequestDto) {
         String email = verifyCodeRequestDto.getEmail();
-        EmailVerification emailVerification = emailVerificationLoadPort.loadOptionEmailVerificationByEmail(email).orElseThrow(() -> CodeNotFoundException.EXCEPTION);
+        EmailVerification emailVerification =
+                emailVerificationLoadPort
+                        .loadOptionEmailVerificationByEmail(email)
+                        .orElseThrow(() -> CodeNotFoundException.EXCEPTION);
         if (!emailVerification.getCode().equals(verifyCodeRequestDto.getCode())) {
             throw CodeNotCorrectException.EXCEPTION;
         }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
@@ -1,0 +1,50 @@
+package com.econovation.recruit.api.user.service;
+
+import com.econovation.recruit.api.user.usecase.SendEmailUseCase;
+import com.econovation.recruitdomain.domains.dto.SendEmailRequestDto;
+import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerification;
+import com.econovation.recruitdomain.out.EmailVerificationLoadPort;
+import com.econovation.recruitdomain.out.EmailVerificationRecordPort;
+import com.econovation.recruitinfrastructure.apache.EmailVerificationSender;
+import java.security.SecureRandom;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService implements SendEmailUseCase {
+    private final EmailVerificationRecordPort emailVerificationRecordPort;
+    private final EmailVerificationLoadPort emailVerificationLoadPort;
+    private final EmailVerificationSender emailVerificationSender;
+
+    private static final String VERIFIED_PREFIX = ":verified";
+    private static final long EMAIL_VERIFICATION_CODE_EXPIRE = Duration.ofMinutes(5).getSeconds();
+
+    @Override
+    public void sendEmail(SendEmailRequestDto sendEmailRequestDto) {
+        String email = sendEmailRequestDto.getEmail();
+
+        if (emailVerificationLoadPort
+                .loadOptionEmailVerificationByEmail(email + VERIFIED_PREFIX)
+                .isPresent()) {
+            emailVerificationRecordPort.delete(email);
+        }
+
+        String code = createCode();
+        EmailVerification emailVerification =
+                EmailVerification.builder()
+                        .email(email)
+                        .code(code)
+                        .expiration(EMAIL_VERIFICATION_CODE_EXPIRE)
+                        .build();
+        emailVerificationRecordPort.save(emailVerification);
+        emailVerificationSender.sendVerificationCode(sendEmailRequestDto.getEmail(), code);
+    }
+
+    private String createCode() {
+        SecureRandom secureRandom = new SecureRandom();
+        int code = 100000 + secureRandom.nextInt(900000);
+        return String.valueOf(code);
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/EmailVerificationService.java
@@ -1,8 +1,12 @@
 package com.econovation.recruit.api.user.service;
 
 import com.econovation.recruit.api.user.usecase.SendEmailUseCase;
+import com.econovation.recruit.api.user.usecase.VerifyCodeUseCase;
 import com.econovation.recruitdomain.domains.dto.SendEmailRequestDto;
+import com.econovation.recruitdomain.domains.dto.VerifyCodeRequestDto;
 import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerification;
+import com.econovation.recruitdomain.domains.email_verification.exception.CodeNotCorrectException;
+import com.econovation.recruitdomain.domains.email_verification.exception.CodeNotFoundException;
 import com.econovation.recruitdomain.out.EmailVerificationLoadPort;
 import com.econovation.recruitdomain.out.EmailVerificationRecordPort;
 import com.econovation.recruitinfrastructure.apache.EmailVerificationSender;
@@ -13,13 +17,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class EmailVerificationService implements SendEmailUseCase {
+public class EmailVerificationService implements SendEmailUseCase, VerifyCodeUseCase {
     private final EmailVerificationRecordPort emailVerificationRecordPort;
     private final EmailVerificationLoadPort emailVerificationLoadPort;
     private final EmailVerificationSender emailVerificationSender;
 
     private static final String VERIFIED_PREFIX = ":verified";
     private static final long EMAIL_VERIFICATION_CODE_EXPIRE = Duration.ofMinutes(5).getSeconds();
+    private static final long EMAIL_VERIFIED_EXPIRE = Duration.ofHours(1).getSeconds();
+    private static final String TRUE = Boolean.TRUE.toString();
 
     @Override
     public void sendEmail(SendEmailRequestDto sendEmailRequestDto) {
@@ -40,6 +46,23 @@ public class EmailVerificationService implements SendEmailUseCase {
                         .build();
         emailVerificationRecordPort.save(emailVerification);
         emailVerificationSender.sendVerificationCode(sendEmailRequestDto.getEmail(), code);
+    }
+
+    @Override
+    public void verifyCode(VerifyCodeRequestDto verifyCodeRequestDto) {
+        String email = verifyCodeRequestDto.getEmail();
+        EmailVerification emailVerification = emailVerificationLoadPort.loadOptionEmailVerificationByEmail(email).orElseThrow(() -> CodeNotFoundException.EXCEPTION);
+        if (!emailVerification.getCode().equals(verifyCodeRequestDto.getCode())) {
+            throw CodeNotCorrectException.EXCEPTION;
+        }
+        EmailVerification verified =
+                EmailVerification.builder()
+                        .email(email + VERIFIED_PREFIX)
+                        .code(TRUE)
+                        .expiration(EMAIL_VERIFIED_EXPIRE)
+                        .build();
+        emailVerificationRecordPort.save(verified);
+        emailVerificationRecordPort.delete(email);
     }
 
     private String createCode() {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
@@ -43,7 +43,11 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
             TokenResponse tokenResponse =
                     jwtTokenProvider.createToken(account.getId(), account.getRole().name());
 
-            AccessToken accessToken = new AccessToken(account.getId(), tokenResponse.getAccessToken(), jwtTokenProvider.getAccessTokenTTlSecond());
+            AccessToken accessToken =
+                    new AccessToken(
+                            account.getId(),
+                            tokenResponse.getAccessToken(),
+                            jwtTokenProvider.getAccessTokenTTlSecond());
             whitelistRecordPort.save(accessToken);
 
             response.addHeader(
@@ -77,7 +81,11 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
         TokenResponse tokenResponse =
                 jwtTokenProvider.createToken(account.getId(), account.getRole().name());
 
-        AccessToken accessToken = new AccessToken(account.getId(), tokenResponse.getAccessToken(), jwtTokenProvider.getAccessTokenTTlSecond());
+        AccessToken accessToken =
+                new AccessToken(
+                        account.getId(),
+                        tokenResponse.getAccessToken(),
+                        jwtTokenProvider.getAccessTokenTTlSecond());
         whitelistRecordPort.save(accessToken);
 
         return tokenResponse;
@@ -125,7 +133,8 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
         if (interviewerLoadPort
                 .loadOptionalInterviewerByEmail(resetPasswordRequestDto.getEmail())
                 .isEmpty()) throw InterviewerIdpServerException.EXCEPTION;
-        Interviewer account = interviewerLoadPort.loadInterviewerByEmail(resetPasswordRequestDto.getEmail());
+        Interviewer account =
+                interviewerLoadPort.loadInterviewerByEmail(resetPasswordRequestDto.getEmail());
         String encededPassword = passwordEncoder.encode(resetPasswordRequestDto.getPassword());
         account.changePassword(encededPassword);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
@@ -10,12 +10,14 @@ import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import com.econovation.recruitdomain.domains.dto.LoginRequestDto;
 import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
+import com.econovation.recruitdomain.domains.email_verification.exception.EmailNotVerifiedException;
 import com.econovation.recruitdomain.domains.interviewer.domain.Interviewer;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerAlreadySubmitException;
 import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerIdpServerException;
 import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerNotMatchException;
 import com.econovation.recruitdomain.domains.whitelist.domain.AccessToken;
+import com.econovation.recruitdomain.out.EmailVerificationLoadPort;
 import com.econovation.recruitdomain.out.InterviewerLoadPort;
 import com.econovation.recruitdomain.out.InterviewerRecordPort;
 import com.econovation.recruitdomain.out.WhitelistRecordPort;
@@ -33,6 +35,9 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final WhitelistRecordPort whitelistRecordPort;
+    private final EmailVerificationLoadPort emailVerificationLoadPort;
+
+    private static final String VERIFIED_PREFIX = ":verified";
 
     @Override
     @Transactional
@@ -130,11 +135,16 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
     @Override
     @Transactional
     public void resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
-        if (interviewerLoadPort
-                .loadOptionalInterviewerByEmail(resetPasswordRequestDto.getEmail())
-                .isEmpty()) throw InterviewerIdpServerException.EXCEPTION;
-        Interviewer account =
-                interviewerLoadPort.loadInterviewerByEmail(resetPasswordRequestDto.getEmail());
+        String email = resetPasswordRequestDto.getEmail();
+        if (emailVerificationLoadPort
+                .loadOptionEmailVerificationByEmail(email + VERIFIED_PREFIX)
+                .isEmpty()) {
+            throw EmailNotVerifiedException.EXCEPTION;
+        }
+
+        if (interviewerLoadPort.loadOptionalInterviewerByEmail(email).isEmpty())
+            throw InterviewerIdpServerException.EXCEPTION;
+        Interviewer account = interviewerLoadPort.loadInterviewerByEmail(email);
         String encededPassword = passwordEncoder.encode(resetPasswordRequestDto.getPassword());
         account.changePassword(encededPassword);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/service/UserService.java
@@ -8,10 +8,12 @@ import com.econovation.recruitcommon.consts.RecruitStatic;
 import com.econovation.recruitcommon.dto.TokenResponse;
 import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import com.econovation.recruitdomain.domains.dto.LoginRequestDto;
+import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Interviewer;
 import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerAlreadySubmitException;
+import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerIdpServerException;
 import com.econovation.recruitdomain.domains.interviewer.exception.InterviewerNotMatchException;
 import com.econovation.recruitdomain.domains.whitelist.domain.AccessToken;
 import com.econovation.recruitdomain.out.InterviewerLoadPort;
@@ -115,5 +117,16 @@ public class UserService implements UserRegisterUseCase, UserLoginUseCase, UserL
     public void logout() {
         Long ipdId = SecurityUtils.getCurrentUserId();
         whitelistRecordPort.deleteById(ipdId);
+    }
+
+    @Override
+    @Transactional
+    public void resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+        if (interviewerLoadPort
+                .loadOptionalInterviewerByEmail(resetPasswordRequestDto.getEmail())
+                .isEmpty()) throw InterviewerIdpServerException.EXCEPTION;
+        Interviewer account = interviewerLoadPort.loadInterviewerByEmail(resetPasswordRequestDto.getEmail());
+        String encededPassword = passwordEncoder.encode(resetPasswordRequestDto.getPassword());
+        account.changePassword(encededPassword);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/SendEmailUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/SendEmailUseCase.java
@@ -1,0 +1,10 @@
+package com.econovation.recruit.api.user.usecase;
+
+import com.econovation.recruitcommon.annotation.UseCase;
+import com.econovation.recruitdomain.domains.dto.SendEmailRequestDto;
+
+@UseCase
+public interface SendEmailUseCase {
+
+    void sendEmail(SendEmailRequestDto sendEmailRequestDto);
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/UserRegisterUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/UserRegisterUseCase.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.user.usecase;
 
 import com.econovation.recruitcommon.annotation.UseCase;
+import com.econovation.recruitdomain.domains.dto.ResetPasswordRequestDto;
 import com.econovation.recruitdomain.domains.dto.SignUpRequestDto;
 
 @UseCase
@@ -9,4 +10,6 @@ public interface UserRegisterUseCase {
     void signUp(SignUpRequestDto signUpRequestDto);
 
     void changePassword(String password);
+
+    void resetPassword(ResetPasswordRequestDto resetPasswordRequestDto);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/VerifyCodeUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/user/usecase/VerifyCodeUseCase.java
@@ -1,0 +1,9 @@
+package com.econovation.recruit.api.user.usecase;
+
+import com.econovation.recruitcommon.annotation.UseCase;
+import com.econovation.recruitdomain.domains.dto.VerifyCodeRequestDto;
+
+@UseCase
+public interface VerifyCodeUseCase {
+    void verifyCode(VerifyCodeRequestDto verifyCodeRequestDto);
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/ResetPasswordRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/ResetPasswordRequestDto.java
@@ -1,0 +1,15 @@
+package com.econovation.recruitdomain.domains.dto;
+
+import com.econovation.recruitcommon.annotation.PasswordValidate;
+import javax.validation.constraints.Email;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class ResetPasswordRequestDto {
+    @Email
+    private String email;
+    @PasswordValidate
+    private String password;
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/ResetPasswordRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/ResetPasswordRequestDto.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 @Data
 @Getter
 public class ResetPasswordRequestDto {
-    @Email
-    private String email;
-    @PasswordValidate
-    private String password;
+    @Email private String email;
+    @PasswordValidate private String password;
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/SendEmailRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/SendEmailRequestDto.java
@@ -1,0 +1,11 @@
+package com.econovation.recruitdomain.domains.dto;
+
+import javax.validation.constraints.Email;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class SendEmailRequestDto {
+    @Email private String email;
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/VerifyCodeRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/VerifyCodeRequestDto.java
@@ -1,0 +1,27 @@
+package com.econovation.recruitdomain.domains.dto;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class VerifyCodeRequestDto {
+    @Email
+    private String email;
+    private String code;
+
+    @AssertTrue(message = "인증 코드는 100000에서 999999 사이의 6자리 숫자여야 합니다")
+    public boolean isCodeValid() {
+        if (code == null) {
+            return false;
+        }
+        try {
+            int codeValue = Integer.parseInt(code);
+            return codeValue >= 100000 && codeValue <= 999999;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/VerifyCodeRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/VerifyCodeRequestDto.java
@@ -8,8 +8,7 @@ import lombok.Getter;
 @Data
 @Getter
 public class VerifyCodeRequestDto {
-    @Email
-    private String email;
+    @Email private String email;
     private String code;
 
     @AssertTrue(message = "인증 코드는 100000에서 999999 사이의 6자리 숫자여야 합니다")

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/adaptor/EmailVerificationAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/adaptor/EmailVerificationAdaptor.java
@@ -1,0 +1,31 @@
+package com.econovation.recruitdomain.domains.email_verification.adaptor;
+
+import com.econovation.recruitcommon.annotation.Adaptor;
+import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerification;
+import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerificationRepository;
+import com.econovation.recruitdomain.out.EmailVerificationLoadPort;
+import com.econovation.recruitdomain.out.EmailVerificationRecordPort;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@Adaptor
+@RequiredArgsConstructor
+public class EmailVerificationAdaptor
+        implements EmailVerificationRecordPort, EmailVerificationLoadPort {
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Override
+    public void save(EmailVerification emailVerification) {
+        emailVerificationRepository.save(emailVerification);
+    }
+
+    @Override
+    public Optional<EmailVerification> loadOptionEmailVerificationByEmail(String email) {
+        return emailVerificationRepository.findById(email);
+    }
+
+    @Override
+    public void delete(String email) {
+        emailVerificationRepository.deleteById(email);
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/domain/EmailVerification.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/domain/EmailVerification.java
@@ -1,0 +1,24 @@
+package com.econovation.recruitdomain.domains.email_verification.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "email_verification")
+public class EmailVerification {
+
+    @Id private String email;
+
+    private String code;
+
+    @TimeToLive private Long expiration;
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/domain/EmailVerificationRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/domain/EmailVerificationRepository.java
@@ -1,0 +1,5 @@
+package com.econovation.recruitdomain.domains.email_verification.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailVerificationRepository extends CrudRepository<EmailVerification, String> {}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotCorrectException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotCorrectException.java
@@ -4,6 +4,7 @@ import com.econovation.recruitcommon.exception.RecruitCodeException;
 
 public class CodeNotCorrectException extends RecruitCodeException {
     public static final CodeNotCorrectException EXCEPTION = new CodeNotCorrectException();
+
     private CodeNotCorrectException() {
         super(EmailVerificationErrorCode.CODE_NOT_CORRECT);
     }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotCorrectException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotCorrectException.java
@@ -1,0 +1,10 @@
+package com.econovation.recruitdomain.domains.email_verification.exception;
+
+import com.econovation.recruitcommon.exception.RecruitCodeException;
+
+public class CodeNotCorrectException extends RecruitCodeException {
+    public static final CodeNotCorrectException EXCEPTION = new CodeNotCorrectException();
+    private CodeNotCorrectException() {
+        super(EmailVerificationErrorCode.CODE_NOT_CORRECT);
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotFoundException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotFoundException.java
@@ -4,6 +4,7 @@ import com.econovation.recruitcommon.exception.RecruitCodeException;
 
 public class CodeNotFoundException extends RecruitCodeException {
     public static final CodeNotFoundException EXCEPTION = new CodeNotFoundException();
+
     private CodeNotFoundException() {
         super(EmailVerificationErrorCode.CODE_NOT_FOUND);
     }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotFoundException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/CodeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.econovation.recruitdomain.domains.email_verification.exception;
+
+import com.econovation.recruitcommon.exception.RecruitCodeException;
+
+public class CodeNotFoundException extends RecruitCodeException {
+    public static final CodeNotFoundException EXCEPTION = new CodeNotFoundException();
+    private CodeNotFoundException() {
+        super(EmailVerificationErrorCode.CODE_NOT_FOUND);
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailNotVerifiedException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailNotVerifiedException.java
@@ -1,0 +1,11 @@
+package com.econovation.recruitdomain.domains.email_verification.exception;
+
+import com.econovation.recruitcommon.exception.RecruitCodeException;
+
+public class EmailNotVerifiedException extends RecruitCodeException {
+    public static final EmailNotVerifiedException EXCEPTION = new EmailNotVerifiedException();
+
+    private EmailNotVerifiedException() {
+        super(EmailVerificationErrorCode.EMAIL_NOT_VERIFIED);
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailVerificationErrorCode.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailVerificationErrorCode.java
@@ -1,0 +1,35 @@
+package com.econovation.recruitdomain.domains.email_verification.exception;
+
+import static com.econovation.recruitcommon.consts.RecruitStatic.BAD_REQUEST;
+import static com.econovation.recruitcommon.consts.RecruitStatic.NOT_FOUND;
+
+import com.econovation.recruitcommon.annotation.ExplainError;
+import com.econovation.recruitcommon.exception.BaseErrorCode;
+import com.econovation.recruitcommon.exception.ErrorReason;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmailVerificationErrorCode implements BaseErrorCode {
+    CODE_NOT_CORRECT(BAD_REQUEST, "EMAIL_VERIFICATION_400_1", "인증코드가 일치하지 않습니다."),
+    CODE_NOT_FOUND(NOT_FOUND, "EMAIL_VERIFICATION_404_1", "인증 요청 정보를 찾을 수 없습니다."),
+    ;
+    private Integer status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailVerificationErrorCode.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/email_verification/exception/EmailVerificationErrorCode.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 public enum EmailVerificationErrorCode implements BaseErrorCode {
     CODE_NOT_CORRECT(BAD_REQUEST, "EMAIL_VERIFICATION_400_1", "인증코드가 일치하지 않습니다."),
     CODE_NOT_FOUND(NOT_FOUND, "EMAIL_VERIFICATION_404_1", "인증 요청 정보를 찾을 수 없습니다."),
+    EMAIL_NOT_VERIFIED(BAD_REQUEST, "EMAIL_VERIFICATION_400_2", "이메일 인증이 완료되지 않았습니다."),
     ;
     private Integer status;
     private String code;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/whitelist/adaptor/WhitelistAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/whitelist/adaptor/WhitelistAdaptor.java
@@ -19,9 +19,7 @@ public class WhitelistAdaptor implements WhitelistRecordPort, WhitelistLoadPort 
 
     @Override
     public void deleteById(Long idpId) {
-        whitelistRepository.findById(idpId)
-                .ifPresent(whitelistRepository::delete);
-
+        whitelistRepository.findById(idpId).ifPresent(whitelistRepository::delete);
     }
 
     @Override

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/whitelist/domain/AccessToken.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/whitelist/domain/AccessToken.java
@@ -16,11 +16,8 @@ import org.springframework.data.redis.core.index.Indexed;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @RedisHash(value = "access_token")
 public class AccessToken {
-    @Id
-    private Long id;
-    @Indexed
-    private String token;
+    @Id private Long id;
+    @Indexed private String token;
 
-    @TimeToLive
-    private Long expiration;
+    @TimeToLive private Long expiration;
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/EmailVerificationLoadPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/EmailVerificationLoadPort.java
@@ -1,0 +1,8 @@
+package com.econovation.recruitdomain.out;
+
+import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerification;
+import java.util.Optional;
+
+public interface EmailVerificationLoadPort {
+    Optional<EmailVerification> loadOptionEmailVerificationByEmail(String email);
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/EmailVerificationRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/EmailVerificationRecordPort.java
@@ -1,0 +1,9 @@
+package com.econovation.recruitdomain.out;
+
+import com.econovation.recruitdomain.domains.email_verification.domain.EmailVerification;
+
+public interface EmailVerificationRecordPort {
+    void save(EmailVerification emailVerification);
+
+    void delete(String email);
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/WhitelistRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/WhitelistRecordPort.java
@@ -4,5 +4,6 @@ import com.econovation.recruitdomain.domains.whitelist.domain.AccessToken;
 
 public interface WhitelistRecordPort {
     void save(AccessToken accessToken);
+
     void deleteById(Long idpId);
 }

--- a/server/Recruit-Domain/src/main/resources/templates/email-verification.html
+++ b/server/Recruit-Domain/src/main/resources/templates/email-verification.html
@@ -13,12 +13,11 @@
 <body style="width:fit-content; height: 100vh; max-width: 1920px; margin: auto; display: block; text-align: center;">
 <section style="padding-top: 100px;">
     <img alt="econo-3d-logo" width="114" height="143" style="color:transparent; margin:auto;" src="https://recruit.econovation.kr/images/econo-3d-logo.png">
-    <h1 style="font-weight: 800; font-size:40px;">신입모집 지원 완료!</h1>
+    <h1 style="font-weight: 800; font-size:40px;">이메일 인증 코드</h1>
     <div style="font-size: 18px;">
-        <div style="margin: 8px;">에코노베이션 <span th:text="${year}"></span>기 지원서가 정상적으로 업로드 되었습니다.</div>
-        <div style="margin: 8px;">서류 합격 결과는 <span th:text="${passedDate}"></span>에 개인 메일로 공지 될 예정입니다.</div>
-        <div style="margin: 8px;"><a class="hover-a" style="color: #2160FF; font-weight: 700;" th:href="@{'https://' + ${domain} + '/applicant/pdf-viewer?id=' + ${applicantId}}">여기</a>에서 지원서를 확인하실 수 있습니다.</div>
-        <div style="margin: 8px;">지원해주셔서 감사합니다.</div>
+        <div style="margin: 8px;">인증코드는 <span th:text="${code}"></span>입니다.</div>
+        <div style="margin: 8px;">사이트에 인증코드를 입력해주세요.</div>
+        <div style="margin: 8px;">감사합니다.</div>
     </div>
 </section>
 </body>

--- a/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/apache/EmailVerificationSender.java
+++ b/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/apache/EmailVerificationSender.java
@@ -1,0 +1,27 @@
+package com.econovation.recruitinfrastructure.apache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailVerificationSender {
+    private final CommonsEmailSender commonsEmailSender;
+    private final TemplateEngine htmlTemplateEngine;
+
+    public void sendVerificationCode(String toEmail, String code) {
+        String subject = "에코노베이션 이메일 인증 코드";
+        String html = generateHtml(code);
+        commonsEmailSender.send(toEmail, subject, html);
+    }
+
+    private String generateHtml(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return htmlTemplateEngine.process("email-verification", context);
+    }
+}


### PR DESCRIPTION
### 개요
close #343 

###  작업사항
- 비밀번호 재설정 기능을 구현했습니다.
- 비밀번호 재설정 과정은 다음과 같습니다.
  - `/api/v1/send-email` 요청을 통해 메일로 인증코드 발송
  - `/api/v1/verify-code` 요청을 통해 인증코드 검증
  - `/api/v1/password/reset` 요청을 통해 비밀번호 재설정
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c7683bf7-f6b1-4ef4-9bc2-222b73426256" />



### 변경로직
- 기존에 종민님 네이버 메일 통해 전송하였는데 에코노베이션 구글 계정으로 메일이 전송되도록 하였습니다.
- 환경변수만 바꾸었고 노션에 로컬, 개발, 운영 환경변수 모두에 대하여 업데이트하였습니다. 


### 참고사항
- 기존에 비밀번호 수정 기능이 있습니다. 하지만 이는 로그인 이후 마이페이지에서 수행할 수 있는 기능이고 현재 마이페이지가 존재하지 않으므로 별도로 재설정 기능을 만들었습니다. 
- 비밀번호 재설정 페이지에 관해서만 작업을 해서 회원가입 시 이메일 인증은 추후 작업할 예정입니다. 