### PR TITLE
[BE-128] 지원서 목록 및 단일 조회 기능 구현 with Graphql

### DIFF
--- a/server/Recruit-Api/build.gradle
+++ b/server/Recruit-Api/build.gradle
@@ -29,6 +29,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // GraphQL
+    implementation 'org.springframework.boot:spring-boot-starter-graphql'
+    implementation 'com.graphql-java:graphql-java-extended-scalars:19.1'
+    testImplementation 'org.springframework.graphql:spring-graphql-test'
+
+
     // websocket client
     implementation 'org.webjars:webjars-locator-core'
     implementation 'org.webjars:sockjs-client:1.0.2'

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/resolver/ApplicantResolver.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/resolver/ApplicantResolver.java
@@ -1,0 +1,38 @@
+package com.econovation.recruit.api.applicant.resolver;
+
+import com.econovation.recruit.api.applicant.dto.AnswersResponseDto;
+import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ApplicantResolver {
+
+    private final ApplicantQueryUseCase applicantQueryUseCase;
+
+    @QueryMapping
+    @PreAuthorize("hasAnyRole('ROLE_ROLE_PRESIDENT', 'ROLE_ROLE_OPERATION', 'ROLE_ROLE_TF')")
+    public AnswersResponseDto getApplicants(
+            @Argument Integer year,
+            @Argument Integer page,
+            @Argument String order,
+            @Argument String searchKeyword,
+            @Argument List<String> requestedQnaFields) {
+        return applicantQueryUseCase.executeFiltered(year, page, order, searchKeyword, requestedQnaFields);
+    }
+
+    @QueryMapping
+    @PreAuthorize("hasAnyRole('ROLE_ROLE_PRESIDENT', 'ROLE_ROLE_OPERATION', 'ROLE_ROLE_TF')")
+    public Map<String, Object> getApplicant(
+            @Argument String applicantId,
+            @Argument List<String> requestedQnaFields
+    ) {
+        return applicantQueryUseCase.executeFiltered(applicantId, requestedQnaFields);
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/resolver/ApplicantResolver.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/resolver/ApplicantResolver.java
@@ -24,15 +24,14 @@ public class ApplicantResolver {
             @Argument String order,
             @Argument String searchKeyword,
             @Argument List<String> requestedQnaFields) {
-        return applicantQueryUseCase.executeFiltered(year, page, order, searchKeyword, requestedQnaFields);
+        return applicantQueryUseCase.executeFiltered(
+                year, page, order, searchKeyword, requestedQnaFields);
     }
 
     @QueryMapping
     @PreAuthorize("hasAnyRole('ROLE_ROLE_PRESIDENT', 'ROLE_ROLE_OPERATION', 'ROLE_ROLE_TF')")
     public Map<String, Object> getApplicant(
-            @Argument String applicantId,
-            @Argument List<String> requestedQnaFields
-    ) {
+            @Argument String applicantId, @Argument List<String> requestedQnaFields) {
         return applicantQueryUseCase.executeFiltered(applicantId, requestedQnaFields);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -11,10 +11,12 @@ import com.econovation.recruit.utils.sort.SortHelper;
 import com.econovation.recruit.utils.vo.PageInfo;
 import com.econovation.recruitdomain.domains.applicant.adaptor.AnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.axonframework.queryhandling.QueryGateway;
@@ -249,5 +251,38 @@ public class ApplicantService implements ApplicantQueryUseCase {
             sortHelper.sort(result, sortType);
         }
         return getQnaMapListWithIdAndPassState(result);
+    }
+
+    @Transactional(readOnly = true)
+    public AnswersResponseDto executeFiltered(
+            Integer year,
+            Integer page,
+            String sortType,
+            String searchKeyword,
+            List<String> requestedQnaFields) {
+
+        PageInfo pageInfo = getPageInfo(year, page, searchKeyword);
+        List<MongoAnswer> sortedResult =
+                answerAdaptor.findByYearAndSearchKeywordAndRequestedFields(year, page, sortType, searchKeyword, requestedQnaFields);
+
+        List<Map<String, Object>> qnaMapList = getQnaMapListWithIdAndPassState(sortedResult);
+
+        if (qnaMapList.isEmpty()) {
+            return AnswersResponseDto.of(Collections.emptyList(), pageInfo);
+        }
+        return AnswersResponseDto.of(qnaMapList, pageInfo);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> executeFiltered(
+            String applicantId, List<String> requestedQnaFields) {
+        MongoAnswer mongoAnswer =
+                answerAdaptor.findByIdAndRequestedFields(applicantId, requestedQnaFields)
+                        .orElseThrow(() -> ApplicantNotFoundException.EXCEPTION);
+
+        Map<String, Object> qna = mongoAnswer.getQna();
+        qna.put("id", mongoAnswer.getId());
+        qna.put(PASS_STATE_KEY, mongoAnswer.getApplicantStateOrDefault());
+        return qna;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.axonframework.queryhandling.QueryGateway;
@@ -263,7 +262,8 @@ public class ApplicantService implements ApplicantQueryUseCase {
 
         PageInfo pageInfo = getPageInfo(year, page, searchKeyword);
         List<MongoAnswer> sortedResult =
-                answerAdaptor.findByYearAndSearchKeywordAndRequestedFields(year, page, sortType, searchKeyword, requestedQnaFields);
+                answerAdaptor.findByYearAndSearchKeywordAndRequestedFields(
+                        year, page, sortType, searchKeyword, requestedQnaFields);
 
         List<Map<String, Object>> qnaMapList = getQnaMapListWithIdAndPassState(sortedResult);
 
@@ -277,7 +277,8 @@ public class ApplicantService implements ApplicantQueryUseCase {
     public Map<String, Object> executeFiltered(
             String applicantId, List<String> requestedQnaFields) {
         MongoAnswer mongoAnswer =
-                answerAdaptor.findByIdAndRequestedFields(applicantId, requestedQnaFields)
+                answerAdaptor
+                        .findByIdAndRequestedFields(applicantId, requestedQnaFields)
                         .orElseThrow(() -> ApplicantNotFoundException.EXCEPTION);
 
         Map<String, Object> qna = mongoAnswer.getQna();

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
@@ -54,6 +54,5 @@ public interface ApplicantQueryUseCase {
             String searchKeyword,
             List<String> requestedQnaFields);
 
-    Map<String, Object> executeFiltered(
-            String applicantId, List<String> requestedQnaFields);
+    Map<String, Object> executeFiltered(String applicantId, List<String> requestedQnaFields);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
@@ -46,4 +46,14 @@ public interface ApplicantQueryUseCase {
     List<MongoAnswer> getApplicantsByYear(Integer year);
 
     MongoAnswer getApplicantById(String applicantId);
+
+    AnswersResponseDto executeFiltered(
+            Integer year,
+            Integer page,
+            String sortType,
+            String searchKeyword,
+            List<String> requestedQnaFields);
+
+    Map<String, Object> executeFiltered(
+            String applicantId, List<String> requestedQnaFields);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
@@ -1,0 +1,68 @@
+package com.econovation.recruit.api.config;
+
+import com.econovation.recruitcommon.exception.BaseErrorCode;
+import com.econovation.recruitcommon.exception.ErrorReason;
+import com.econovation.recruitcommon.exception.GlobalErrorCode;
+import com.econovation.recruitcommon.exception.RecruitCodeException;
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
+import org.springframework.stereotype.Component;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter {
+
+    @Override
+    protected GraphQLError resolveToSingleError(Throwable ex, DataFetchingEnvironment env) {
+
+        // 1. RecruitCodeException 처리 (비즈니스 예외)
+        if (ex instanceof RecruitCodeException recruitCodeException) {
+            return handleRecruitCodeException(recruitCodeException, env);
+        }
+
+        // 2. 이외의 예외는 내부 서버 오류로 처리
+        return handleInternalServerError(ex, env);
+    }
+
+    private GraphQLError handleRecruitCodeException(RecruitCodeException ex, DataFetchingEnvironment env) {
+        BaseErrorCode errorCode = ex.getErrorCode();
+        ErrorReason errorReason = errorCode.getErrorReason();
+
+        return GraphqlErrorBuilder.newError()
+                .message(errorReason.getReason())
+                .errorType(ErrorType.DataFetchingException)
+                .location(env.getField().getSourceLocation())
+                .path(env.getExecutionStepInfo().getPath())
+                .extensions(Map.of(
+                        "code", errorReason.getCode(),
+                        "status", errorReason.getStatus(),
+                        "timestamp", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
+                ))
+                .build();
+    }
+
+    private GraphQLError handleInternalServerError(Throwable ex, DataFetchingEnvironment env) {
+
+        GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+
+        return GraphqlErrorBuilder.newError()
+                .message(internalServerError.getReason())
+                .errorType(ErrorType.DataFetchingException)
+                .location(env.getField().getSourceLocation())
+                .path(env.getExecutionStepInfo().getPath())
+                .extensions(Map.of(
+                        "code", internalServerError.getCode(),
+                        "status", internalServerError.getStatus(),
+                        "timestamp", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
+                ))
+                .build();
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
@@ -7,14 +7,13 @@ import com.econovation.recruitcommon.exception.RecruitCodeException;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter;
 import org.springframework.stereotype.Component;
-import graphql.schema.DataFetchingEnvironment;
-
-import java.util.Map;
 
 @Component
 @Slf4j
@@ -32,7 +31,8 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
         return handleInternalServerError(ex, env);
     }
 
-    private GraphQLError handleRecruitCodeException(RecruitCodeException ex, DataFetchingEnvironment env) {
+    private GraphQLError handleRecruitCodeException(
+            RecruitCodeException ex, DataFetchingEnvironment env) {
         BaseErrorCode errorCode = ex.getErrorCode();
         ErrorReason errorReason = errorCode.getErrorReason();
 
@@ -41,11 +41,15 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
                 .errorType(ErrorType.DataFetchingException)
                 .location(env.getField().getSourceLocation())
                 .path(env.getExecutionStepInfo().getPath())
-                .extensions(Map.of(
-                        "code", errorReason.getCode(),
-                        "status", errorReason.getStatus(),
-                        "timestamp", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
-                ))
+                .extensions(
+                        Map.of(
+                                "code", errorReason.getCode(),
+                                "status", errorReason.getStatus(),
+                                "timestamp",
+                                        LocalDateTime.now()
+                                                .format(
+                                                        DateTimeFormatter.ofPattern(
+                                                                "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))))
                 .build();
     }
 
@@ -58,11 +62,15 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
                 .errorType(ErrorType.DataFetchingException)
                 .location(env.getField().getSourceLocation())
                 .path(env.getExecutionStepInfo().getPath())
-                .extensions(Map.of(
-                        "code", internalServerError.getCode(),
-                        "status", internalServerError.getStatus(),
-                        "timestamp", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
-                ))
+                .extensions(
+                        Map.of(
+                                "code", internalServerError.getCode(),
+                                "status", internalServerError.getStatus(),
+                                "timestamp",
+                                        LocalDateTime.now()
+                                                .format(
+                                                        DateTimeFormatter.ofPattern(
+                                                                "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))))
                 .build();
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
@@ -36,20 +36,12 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
         BaseErrorCode errorCode = ex.getErrorCode();
         ErrorReason errorReason = errorCode.getErrorReason();
 
-        return GraphqlErrorBuilder.newError()
-                .message(errorReason.getReason())
-                .errorType(ErrorType.DataFetchingException)
-                .location(env.getField().getSourceLocation())
-                .path(env.getExecutionStepInfo().getPath())
-                .extensions(
-                        Map.of(
-                                "code", errorReason.getCode(),
-                                "status", errorReason.getStatus(),
-                                "timestamp",
-                                        LocalDateTime.now()
-                                                .format(
-                                                        DateTimeFormatter.ofPattern(
-                                                                "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))))
+        return createErrorBuilder(
+                errorReason.getReason(),
+                ErrorType.DataFetchingException,
+                env,
+                errorReason.getCode(),
+                errorReason.getStatus())
                 .build();
     }
 
@@ -57,20 +49,33 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
 
         GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
 
+        return createErrorBuilder(
+                internalServerError.getReason(),
+                ErrorType.DataFetchingException,
+                env,
+                internalServerError.getCode(),
+                internalServerError.getStatus()).build();
+    }
+
+    private GraphqlErrorBuilder createErrorBuilder(
+            String message,
+            ErrorType errorType,
+            DataFetchingEnvironment env,
+            String code,
+            Integer status
+    ) {
         return GraphqlErrorBuilder.newError()
-                .message(internalServerError.getReason())
-                .errorType(ErrorType.DataFetchingException)
+                .message(message)
+                .errorType(errorType)
                 .location(env.getField().getSourceLocation())
                 .path(env.getExecutionStepInfo().getPath())
                 .extensions(
                         Map.of(
-                                "code", internalServerError.getCode(),
-                                "status", internalServerError.getStatus(),
-                                "timestamp",
-                                        LocalDateTime.now()
-                                                .format(
-                                                        DateTimeFormatter.ofPattern(
-                                                                "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))))
-                .build();
+                                "code", code,
+                                "status", status,
+                                "timestamp", LocalDateTime.now()
+                                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
+                        )
+                );
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/GraphQLExceptionHandler.java
@@ -37,11 +37,11 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
         ErrorReason errorReason = errorCode.getErrorReason();
 
         return createErrorBuilder(
-                errorReason.getReason(),
-                ErrorType.DataFetchingException,
-                env,
-                errorReason.getCode(),
-                errorReason.getStatus())
+                        errorReason.getReason(),
+                        ErrorType.DataFetchingException,
+                        env,
+                        errorReason.getCode(),
+                        errorReason.getStatus())
                 .build();
     }
 
@@ -50,11 +50,12 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
         GlobalErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
 
         return createErrorBuilder(
-                internalServerError.getReason(),
-                ErrorType.DataFetchingException,
-                env,
-                internalServerError.getCode(),
-                internalServerError.getStatus()).build();
+                        internalServerError.getReason(),
+                        ErrorType.DataFetchingException,
+                        env,
+                        internalServerError.getCode(),
+                        internalServerError.getStatus())
+                .build();
     }
 
     private GraphqlErrorBuilder createErrorBuilder(
@@ -62,8 +63,7 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
             ErrorType errorType,
             DataFetchingEnvironment env,
             String code,
-            Integer status
-    ) {
+            Integer status) {
         return GraphqlErrorBuilder.newError()
                 .message(message)
                 .errorType(errorType)
@@ -73,9 +73,10 @@ public class GraphQLExceptionHandler extends DataFetcherExceptionResolverAdapter
                         Map.of(
                                 "code", code,
                                 "status", status,
-                                "timestamp", LocalDateTime.now()
-                                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))
-                        )
-                );
+                                "timestamp",
+                                        LocalDateTime.now()
+                                                .format(
+                                                        DateTimeFormatter.ofPattern(
+                                                                "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"))));
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/HttpContentCacheFilter.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/HttpContentCacheFilter.java
@@ -5,13 +5,23 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Component
+@RequiredArgsConstructor
 public class HttpContentCacheFilter extends OncePerRequestFilter {
+
+    private final PathExclusionStrategy pathExclusionStrategy;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return pathExclusionStrategy.shouldExclude(request.getRequestURI());
+    }
+
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain chain)

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/PathExclusionStrategy.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/PathExclusionStrategy.java
@@ -1,0 +1,5 @@
+package com.econovation.recruit.api.config;
+
+public interface PathExclusionStrategy {
+    boolean shouldExclude(String path);
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLConfig.java
@@ -1,0 +1,28 @@
+package com.econovation.recruit.api.config.graphql;
+
+import graphql.scalars.ExtendedScalars;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.execution.RuntimeWiringConfigurer;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class GraphQLConfig {
+
+    @Bean
+    public RuntimeWiringConfigurer runtimeWiringConfigurer() {
+        return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.Json);
+    }
+    @Bean
+    public WebMvcConfigurer webMvcConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+                converters.add(new MappingJackson2HttpMessageConverter());
+            }
+        };
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLConfig.java
@@ -16,6 +16,7 @@ public class GraphQLConfig {
     public RuntimeWiringConfigurer runtimeWiringConfigurer() {
         return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.Json);
     }
+
     @Bean
     public WebMvcConfigurer webMvcConfigurer() {
         return new WebMvcConfigurer() {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLPathExclusionStrategy.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLPathExclusionStrategy.java
@@ -1,0 +1,13 @@
+package com.econovation.recruit.api.config.graphql;
+
+import com.econovation.recruit.api.config.PathExclusionStrategy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GraphQLPathExclusionStrategy implements PathExclusionStrategy {
+
+    @Override
+    public boolean shouldExclude(String requestPath) {
+        return requestPath.startsWith("/graphql");
+    }
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -24,6 +25,7 @@ import org.springframework.security.web.access.expression.DefaultWebSecurityExpr
 
 @RequiredArgsConstructor
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
     private final FilterConfig filterConfig;
 
@@ -75,6 +77,8 @@ public class SecurityConfig {
                 // 따라서 스웨거용 인메모리 유저가 basic auth 필터를 통과해서 들어오더라도
                 // ( jwt 필터나 , basic auth 필터의 순서는 상관이없다.) --> 왜냐면 jwt는 토큰 여부 파악만하고 있으면 검증이고 없으면 넘김.
                 // 내부 소스까지 실행을 못함. 권한 문제 때문에.
+                .mvcMatchers(HttpMethod.POST, "/graphql")
+                .permitAll()
                 .mvcMatchers(HttpMethod.DELETE, "/api/v1//interviewers/*")
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
                 .mvcMatchers(HttpMethod.PATCH, "/api/v1/applicants/{applicant-id}/status")

--- a/server/Recruit-Api/src/main/resources/application.yml
+++ b/server/Recruit-Api/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+  graphql:
+    schema:
+      locations: classpath:graphql/**/
 data:
   init:
     disabled: ${DATA_INIT_DISABLED:false}
@@ -100,9 +103,10 @@ econovation:
   file:
     path:
       portfolio: ${ECONOVATION_PORTFOLIO_PATH:server/portfolio.pdf}
-#logging:
-#  level:
-#    root: info
+logging:
+  level:
+    root: info
+    graphql: debug
 #logging:
 #  level:
 #    org.springframework.data.*.*: debug

--- a/server/Recruit-Api/src/main/resources/graphql/schema.graphqls
+++ b/server/Recruit-Api/src/main/resources/graphql/schema.graphqls
@@ -1,0 +1,31 @@
+scalar JSON
+
+type Query {
+
+  getApplicants(
+    year: Int!,
+    page: Int!,
+    order: String,
+    searchKeyword: String,
+    requestedQnaFields: [String!]
+  ): AnswerResponse!
+
+  getApplicant(
+    applicantId: String,
+    requestedQnaFields: [String!]
+  ): JSON!
+}
+
+type PageInfo {
+  currentPage: Int!,
+  listCount: Int!,
+  pageLimit: Int!,
+  startPage: Int!,
+  endPage: Int!,
+  boardLimit: Int!
+}
+
+type AnswerResponse {
+    pageInfo: PageInfo!
+    answers: [JSON!]
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -6,8 +6,8 @@ import com.econovation.recruitcommon.annotation.Adaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerRepository;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -159,9 +159,12 @@ public class AnswerAdaptor {
         return mongoTemplate.find(query, MongoAnswer.class);
     }
 
-
     public List<MongoAnswer> findByYearAndSearchKeywordAndRequestedFields(
-            Integer year, Integer page, String sortType, String searchKeyword, List<String> requestedQnaFields) {
+            Integer year,
+            Integer page,
+            String sortType,
+            String searchKeyword,
+            List<String> requestedQnaFields) {
 
         Query query =
                 new Query()
@@ -180,10 +183,9 @@ public class AnswerAdaptor {
         return mongoTemplate.find(query, MongoAnswer.class);
     }
 
-    public Optional<MongoAnswer> findByIdAndRequestedFields(String applicantId, List<String> requestedQnaFields) {
-        Query query =
-                new Query()
-                        .addCriteria(Criteria.where("id").is(applicantId));
+    public Optional<MongoAnswer> findByIdAndRequestedFields(
+            String applicantId, List<String> requestedQnaFields) {
+        Query query = new Query().addCriteria(Criteria.where("id").is(applicantId));
 
         if (requestedQnaFields != null && !requestedQnaFields.isEmpty()) {
             requestedQnaFields.forEach(field -> query.fields().include("qna." + field));

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -6,6 +6,7 @@ import com.econovation.recruitcommon.annotation.Adaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerRepository;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
+import java.util.Optional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +22,7 @@ import org.springframework.data.mongodb.core.query.TextQuery;
 @Adaptor
 @RequiredArgsConstructor
 public class AnswerAdaptor {
+
     private final MongoTemplate mongoTemplate;
     private final MongoAnswerRepository answerRepository;
 
@@ -155,5 +157,39 @@ public class AnswerAdaptor {
         addCriteriaIfSearchKeywordExists(searchKeyword, query);
 
         return mongoTemplate.find(query, MongoAnswer.class);
+    }
+
+
+    public List<MongoAnswer> findByYearAndSearchKeywordAndRequestedFields(
+            Integer year, Integer page, String sortType, String searchKeyword, List<String> requestedQnaFields) {
+
+        Query query =
+                new Query()
+                        .addCriteria(Criteria.where("year").is(year))
+                        .skip((page - 1) * 10L)
+                        .limit(PAGE_SIZE);
+
+        setSortType(query, sortType);
+
+        addCriteriaIfSearchKeywordExists(searchKeyword, query);
+
+        if (requestedQnaFields != null && !requestedQnaFields.isEmpty()) {
+            requestedQnaFields.forEach(field -> query.fields().include("qna." + field));
+        }
+
+        return mongoTemplate.find(query, MongoAnswer.class);
+    }
+
+    public Optional<MongoAnswer> findByIdAndRequestedFields(String applicantId, List<String> requestedQnaFields) {
+        Query query =
+                new Query()
+                        .addCriteria(Criteria.where("id").is(applicantId));
+
+        if (requestedQnaFields != null && !requestedQnaFields.isEmpty()) {
+            requestedQnaFields.forEach(field -> query.fields().include("qna." + field));
+        }
+
+        MongoAnswer result = mongoTemplate.findOne(query, MongoAnswer.class);
+        return Optional.ofNullable(result);
     }
 }


### PR DESCRIPTION
### 개요
close #342 

###  작업사항
- 지원서 목록 및 단일 조회 시 필요한 필드만 요청 받아 전달하도록 구현하였습니다.(GraphQL 적용)

### 변경로직
- 기존 `/page/{page}/year/{year}/applicants`에서 목록과 함께 지원자의 모든 정보를 반환하던 로직에서 필요한 필드만 GraphQL을 통해 처리가능한 기능을 추가하였습니다.


### reference
__목록 조회 예시__
```json
{
  "query": "query { getApplicants(year: 29, page: 1, order: \"newest\", searchKeyword: \"\", requestedQnaFields: [\"field\", \"field1\", \"field2\"]) { pageInfo { currentPage listCount pageLimit startPage endPage boardLimit } answers } }"
}
```

__단일 조회 예시__
```json
{
  "query": "query { getApplicant(applicantId: \"6cf13c38-cf5e-45e6-9590-9970adb2b14e\", requestedQnaFields: [\"field\", \"field1\", \"field2\", \"specificField\", \"name\", \"contacted\", \"classOf\", \"registered\", \"grade\", \"semester\", \"major\", \"doubleMajor\", \"minor\", \"activity\", \"reason\", \"future\", \"experience\", \"deep\", \"restoration\", \"collaboration\", \"studyPlan\", \"portfolio\", \"fileUrl\", \"check\", \"email\", \"personalInformationAgree\", \"personalInformationAgreeForPortfolio\", \"generation\", \"uploadDate\", \"channel\", \"timeline\", \"created_at\", \"year\", \"passState\"]) }"
}
```

__/graphql 요청에 대한 토큰의 유무에 따른 에러__
- Authorization Header가 없는 경우 403 Forbidden. 빈 Body
- Authorization Header에 잘못 된 토큰이 있는 경우 401 에러, 커스텀 Body
- 단일 조회에서 applicantId가 존재하지 않는 경우 커스텀 에러가 발생합니다.

GraphQL에서는 에러의 경우에도 200 OK를 반환하며 에러 메시지를 통해 상세한 내용을 기술한다고 합니다.