### PR TITLE
[BE-132] Graphql 경로 /graphql 에서 /api/graphql로 변경

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLPathExclusionStrategy.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/graphql/GraphQLPathExclusionStrategy.java
@@ -8,6 +8,6 @@ public class GraphQLPathExclusionStrategy implements PathExclusionStrategy {
 
     @Override
     public boolean shouldExclude(String requestPath) {
-        return requestPath.startsWith("/graphql");
+        return requestPath.startsWith("/api/graphql");
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
                 // 따라서 스웨거용 인메모리 유저가 basic auth 필터를 통과해서 들어오더라도
                 // ( jwt 필터나 , basic auth 필터의 순서는 상관이없다.) --> 왜냐면 jwt는 토큰 여부 파악만하고 있으면 검증이고 없으면 넘김.
                 // 내부 소스까지 실행을 못함. 권한 문제 때문에.
-                .mvcMatchers(HttpMethod.POST, "/graphql")
+                .mvcMatchers(HttpMethod.POST, "/api/graphql")
                 .permitAll()
                 .mvcMatchers(HttpMethod.DELETE, "/api/v1//interviewers/*")
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")

--- a/server/Recruit-Api/src/main/resources/application.yml
+++ b/server/Recruit-Api/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
   graphql:
+    path: /api/graphql
     schema:
       locations: classpath:graphql/**/
 data:


### PR DESCRIPTION
### 개요
close #350 

###  작업사항
- Graphql 경로 변경
- 기존: /graphql
- 변경: /api/graphql

### 변경로직
- `HttpContentCacheFilter`를 안 거치는 경로 `/graphql`에서 /api/graphql` 변경
- Graphql 요청 엔드포인트 `/graphql`에서 `/api/graphql` 변경

