### PR TITLE
[BE-133] 등록된 모집이 존재하지 않을경우, 유효성 검증 시 예외가 발생하는 오류 수정

### DIFF
--- a/server/Recruit-Api/src/main/resources/application.yml
+++ b/server/Recruit-Api/src/main/resources/application.yml
@@ -110,7 +110,6 @@ econovation:
       portfolio: ${ECONOVATION_PORTFOLIO_PATH:server/portfolio.pdf}
 logging:
   level:
-    root: info
     graphql: debug
 #logging:
 #  level:

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
@@ -24,7 +24,13 @@ public class RecruitmentAdaptor implements RecruitmentPort {
 
     @Override
     public Optional<Recruitment> findLatestOne() {
-        return Optional.ofNullable(repository.findLatestOne().get(0));
+        List<Recruitment> recruitments = repository.findAllOrderByUpdatedAt();
+
+        if(!recruitments.isEmpty()) {
+            return Optional.ofNullable(recruitments.get(0));
+        }
+
+        return Optional.empty();
     }
 
     @Override

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
 
     @Query("SELECT r FROM Recruitment r ORDER BY r.updatedAt DESC")
-    List<Recruitment> findLatestOne();
+    List<Recruitment> findAllOrderByUpdatedAt();
 
     @Query("SELECT r FROM Recruitment r WHERE r.states=:states ORDER BY r.updatedAt DESC")
     List<Recruitment> findByStates(@Param("states") RecruitmentStates states);


### PR DESCRIPTION
### 개요
close #

###  작업사항
- RecruitmentLoadPort에 정의된 잘못된 메소드로 인해, RecruitmentService에서 새로운 모집 생성에 대한 유효성 검증 시, indexOutOfBoundException이 발생하는 오류를 수정합니다.

- 애플리케이션 전체의 로그 레벨이 info로 되어있어, 해당 부분을 삭제하였습니다.

### 변경로직
- RecruitmentLoadPort에 정의된 findLatestOne 메소드 내부를 수정하였습니다.


### reference

- 