### PR TITLE
[BE-138] Recruitment 등록 시 Columns 을 자동으로 생성합니다.

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
@@ -4,6 +4,7 @@ import static com.econovation.recruitcommon.consts.RecruitStatic.*;
 
 import com.econovation.recruit.api.card.usecase.BoardLoadUseCase;
 import com.econovation.recruit.api.card.usecase.BoardRegisterUseCase;
+import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitcommon.utils.Result;
 import com.econovation.recruitdomain.common.aop.redissonLock.RedissonLock;
 import com.econovation.recruitdomain.domains.board.domain.Board;
@@ -40,9 +41,7 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
     private final BoardLoadPort boardLoadPort;
     private final ColumnLoadPort columnLoadPort;
     private final ColumnRecordPort columnRecordPort;
-
-    @Value("${econovation.year}")
-    private Integer econovationYear;
+    private final LatestRecruitmentVo latestRecruitmentVo;
 
     /*    @Override
     public Board save(Map<String, Integer> newestLocation, String hopeField, Integer navLoc) {
@@ -203,6 +202,7 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
     @Override
     @Transactional
     public Columns createColumn(String title, Integer navigationId) {
+        int econovationYear = latestRecruitmentVo.getYear();
         Columns column =
                 Columns.builder()
                         .title(title)

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
@@ -10,35 +10,32 @@ import org.springframework.stereotype.Component;
 public class ColumnsUtil {
 
     /**
-     * 리스트를 순회하며, 중간에 nextBoardId가 null 인 것을 찾으면 바로 반환하고,
-     * 리스트를 모두 순회했는데, 찾지 못하면 마지막 인덱스 반환
+     * 리스트를 순회하며, 중간에 nextBoardId가 null 인 것을 찾으면 바로 반환하고, 리스트를 모두 순회했는데, 찾지 못하면 마지막 인덱스 반환
+     *
      * @param columns
      * @return
      */
-    public static int findNextColumnIdIsNull(List<Columns> columns){
+    public static int findNextColumnIdIsNull(List<Columns> columns) {
 
-        for(int i=0; i<columns.size(); i++){
+        for (int i = 0; i < columns.size(); i++) {
             Columns c = columns.get(i);
 
-            if(c.getNextColumnsId()==null) return i;
+            if (c.getNextColumnsId() == null) return i;
         }
 
-        return columns.size()-1;
+        return columns.size() - 1;
     }
 
-    public static List<Columns> connectAll(List<Columns> columns){
+    public static List<Columns> connectAll(List<Columns> columns) {
         // 0 -> 1 -> 2 이렇게 연결한다.
-        for(int i=0; i<columns.size()-1; i++){
-            connect(columns.get(i), columns.get(i+1));
+        for (int i = 0; i < columns.size() - 1; i++) {
+            connect(columns.get(i), columns.get(i + 1));
         }
 
         return columns;
     }
 
-    public static void connect(Columns before, Columns after){
+    public static void connect(Columns before, Columns after) {
         before.updateNextColumnsId(after.getId());
     }
-
-
-
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
@@ -1,0 +1,44 @@
+package com.econovation.recruit.api.card.util;
+
+import com.econovation.recruitdomain.domains.board.domain.Columns;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ColumnsUtil {
+
+    /**
+     * 리스트를 순회하며, 중간에 nextBoardId가 null 인 것을 찾으면 바로 반환하고,
+     * 리스트를 모두 순회했는데, 찾지 못하면 마지막 인덱스 반환
+     * @param columns
+     * @return
+     */
+    public static int findNextColumnIdIsNull(List<Columns> columns){
+
+        for(int i=0; i<columns.size(); i++){
+            Columns c = columns.get(i);
+
+            if(c.getNextColumnsId()==null) return i;
+        }
+
+        return columns.size()-1;
+    }
+
+    public static List<Columns> connectAll(List<Columns> columns){
+        // 0 -> 1 -> 2 이렇게 연결한다.
+        for(int i=0; i<columns.size()-1; i++){
+            connect(columns.get(i), columns.get(i+1));
+        }
+
+        return columns;
+    }
+
+    public static void connect(Columns before, Columns after){
+        before.updateNextColumnsId(after.getId());
+    }
+
+
+
+}

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
@@ -26,11 +26,13 @@ public class ColumnsUtil {
         return columns.size() - 1;
     }
 
-    public static boolean isSatisfiedCommonColumns(List<Columns> columns){
-        int developer = 1; int designer = 1; int productManager = 1;
+    public static boolean isSatisfiedCommonColumns(List<Columns> columns) {
+        int developer = 1;
+        int designer = 1;
+        int productManager = 1;
 
-        for(Columns c : columns){
-            switch (c.getTitle()){
+        for (Columns c : columns) {
+            switch (c.getTitle()) {
                 case "개발자":
                     developer--;
                     break;
@@ -43,7 +45,7 @@ public class ColumnsUtil {
             }
         }
 
-        return developer+designer+productManager==0;
+        return developer + designer + productManager == 0;
     }
 
     public static List<Columns> connectAll(List<Columns> columns) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/util/ColumnsUtil.java
@@ -26,6 +26,26 @@ public class ColumnsUtil {
         return columns.size() - 1;
     }
 
+    public static boolean isSatisfiedCommonColumns(List<Columns> columns){
+        int developer = 1; int designer = 1; int productManager = 1;
+
+        for(Columns c : columns){
+            switch (c.getTitle()){
+                case "개발자":
+                    developer--;
+                    break;
+                case "디자이너":
+                    designer--;
+                    break;
+                case "기획자":
+                    productManager--;
+                    break;
+            }
+        }
+
+        return developer+designer+productManager==0;
+    }
+
     public static List<Columns> connectAll(List<Columns> columns) {
         // 0 -> 1 -> 2 이렇게 연결한다.
         for (int i = 0; i < columns.size() - 1; i++) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -80,7 +80,7 @@ public class RecruitmentRegisteredEventHandler {
     private List<String> filterNotExists(List<String> columnNames, int year) {
         return columnNames.stream()
                 .filter(name -> !columnLoadPort.existsColumnsByTitle(name, year))
-                .peek(name -> System.out.println(String.format("%s 컬럼 존재", name)))
+                .peek(name -> log.info("{} 기수에 {} 컬럼이 존재하지 않아 생성합니다.", year, name))
                 .toList();
     }
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -1,9 +1,17 @@
 package com.econovation.recruit.api.recruitment.handler;
 
+import com.econovation.recruit.api.card.util.ColumnsUtil;
 import com.econovation.recruit.api.recruitment.quartz.RecruitmentScheduler;
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
+import com.econovation.recruitdomain.domains.board.domain.Board;
+import com.econovation.recruitdomain.domains.board.domain.Columns;
 import com.econovation.recruitdomain.domains.recruitment.event.RecruitmentRegistered;
+import com.econovation.recruitdomain.out.BoardLoadPort;
+import com.econovation.recruitdomain.out.BoardRecordPort;
+import com.econovation.recruitdomain.out.ColumnLoadPort;
+import com.econovation.recruitdomain.out.ColumnRecordPort;
 import com.econovation.recruitdomain.out.RecruitmentPort;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -19,10 +27,19 @@ public class RecruitmentRegisteredEventHandler {
     private final RecruitmentScheduler recruitmentScheduler;
     private final LatestRecruitmentVo latestRecruitment;
 
+    private final ColumnLoadPort columnLoadPort;
+    private final ColumnRecordPort columnRecordPort;
+
+    private final BoardLoadPort boardLoadPort;
+    private final BoardRecordPort boardRecordPort;
+
     @Transactional
     @EventListener(RecruitmentRegistered.class)
     public void handle(RecruitmentRegistered event) {
-
+        doReserve(event);
+        createCommonColumn();
+    }
+    private void doReserve(RecruitmentRegistered event){
         // 1. 전역 상태 최신화
         // 2. NON_START 상태를, startAt 시간이 되면 RECRUITING 상태로 변경하는 작업 예약
         // 3. RECRUITING 상태를, endAt 시간이 되면, END 상태로 변경하는 작업 예약
@@ -34,5 +51,39 @@ public class RecruitmentRegisteredEventHandler {
                             recruitmentScheduler.reserveStart(recruitment);
                             recruitmentScheduler.reserveEnd(recruitment);
                         });
+    }
+
+    /**
+     * 새로운 모집이 등록되었으므로, 새로운 기수에 맞는 개발자,디자이너,기획자 컬럼을 새로 추가합니다.
+     */
+    private void createCommonColumn(){
+        int year = latestRecruitment.getYear();
+
+        List<String> columnNames = List.of("개발자", "디자이너", "기획자");
+
+        List<Columns> commonColumns = columnNames.stream().map(name->Columns.createCommonColumn(name, year)).toList();
+        List<Columns> saved = columnRecordPort.saveAll(commonColumns);
+
+        List<Columns> existColumns = columnLoadPort.getColumnsByNavigationIdAndYear(1, year);
+
+        connect(existColumns);
+        createInvisibleBoards(existColumns);
+    }
+
+    /**
+     * 끊긴 컬럼들을 찾아서 연결합니다.
+     * @param columns
+     */
+    private void connect(List<Columns> columns){
+        int start = ColumnsUtil.findNextColumnIdIsNull(columns);
+        int end = columns.size();
+
+        // 0 -> 1 -> 2
+        ColumnsUtil.connectAll(columns.subList(start, end));
+    }
+
+    private void createInvisibleBoards(List<Columns> columns){
+        List<Board> invisibleBoards = columns.stream().map(c-> Board.creatInvisibleBoard(c.getId(), 1)).toList();
+        boardRecordPort.saveAll(invisibleBoards);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -18,8 +18,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.interceptor.TransactionAspectSupport;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Component

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -62,9 +62,11 @@ public class RecruitmentRegisteredEventHandler {
         columnNames = filterNotExists(columnNames, year);
 
         // 모든 컬럼이 존재하지 않으면
-        if(!columnNames.isEmpty()) {
+        if (!columnNames.isEmpty()) {
             List<Columns> commonColumns =
-                    columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
+                    columnNames.stream()
+                            .map(name -> Columns.createCommonColumn(name, year))
+                            .toList();
 
             List<Columns> saved = columnRecordPort.saveAll(commonColumns);
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -56,18 +56,26 @@ public class RecruitmentRegisteredEventHandler {
 
     /** 새로운 모집이 등록되었으므로, 새로운 기수에 맞는 개발자,디자이너,기획자 컬럼을 새로 추가합니다. */
     private void createCommonColumn() {
+        List<String> columnNames = List.of("개발자", "디자이너", "기획자");
         int year = latestRecruitment.getYear();
 
-        List<String> columnNames = List.of("개발자", "디자이너", "기획자");
+        if(isExists(columnNames, year)) return;
 
         List<Columns> commonColumns =
                 columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
+
         List<Columns> saved = columnRecordPort.saveAll(commonColumns);
 
         List<Columns> existColumns = columnLoadPort.getColumnsByNavigationIdAndYear(1, year);
 
         connect(existColumns);
         createInvisibleBoards(existColumns);
+    }
+
+    private boolean isExists(List<String> columnNames, int year){
+        return columnNames.stream()
+                .map(name -> columnLoadPort.existsColumnsByTitle(name, year))
+                .reduce(true, (b1,b2)->b1&&b2);
     }
 
     /**

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -39,7 +39,8 @@ public class RecruitmentRegisteredEventHandler {
         doReserve(event);
         createCommonColumn();
     }
-    private void doReserve(RecruitmentRegistered event){
+
+    private void doReserve(RecruitmentRegistered event) {
         // 1. 전역 상태 최신화
         // 2. NON_START 상태를, startAt 시간이 되면 RECRUITING 상태로 변경하는 작업 예약
         // 3. RECRUITING 상태를, endAt 시간이 되면, END 상태로 변경하는 작업 예약
@@ -53,15 +54,14 @@ public class RecruitmentRegisteredEventHandler {
                         });
     }
 
-    /**
-     * 새로운 모집이 등록되었으므로, 새로운 기수에 맞는 개발자,디자이너,기획자 컬럼을 새로 추가합니다.
-     */
-    private void createCommonColumn(){
+    /** 새로운 모집이 등록되었으므로, 새로운 기수에 맞는 개발자,디자이너,기획자 컬럼을 새로 추가합니다. */
+    private void createCommonColumn() {
         int year = latestRecruitment.getYear();
 
         List<String> columnNames = List.of("개발자", "디자이너", "기획자");
 
-        List<Columns> commonColumns = columnNames.stream().map(name->Columns.createCommonColumn(name, year)).toList();
+        List<Columns> commonColumns =
+                columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
         List<Columns> saved = columnRecordPort.saveAll(commonColumns);
 
         List<Columns> existColumns = columnLoadPort.getColumnsByNavigationIdAndYear(1, year);
@@ -72,9 +72,10 @@ public class RecruitmentRegisteredEventHandler {
 
     /**
      * 끊긴 컬럼들을 찾아서 연결합니다.
+     *
      * @param columns
      */
-    private void connect(List<Columns> columns){
+    private void connect(List<Columns> columns) {
         int start = ColumnsUtil.findNextColumnIdIsNull(columns);
         int end = columns.size();
 
@@ -82,8 +83,9 @@ public class RecruitmentRegisteredEventHandler {
         ColumnsUtil.connectAll(columns.subList(start, end));
     }
 
-    private void createInvisibleBoards(List<Columns> columns){
-        List<Board> invisibleBoards = columns.stream().map(c-> Board.creatInvisibleBoard(c.getId(), 1)).toList();
+    private void createInvisibleBoards(List<Columns> columns) {
+        List<Board> invisibleBoards =
+                columns.stream().map(c -> Board.creatInvisibleBoard(c.getId(), 1)).toList();
         boardRecordPort.saveAll(invisibleBoards);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -59,7 +59,7 @@ public class RecruitmentRegisteredEventHandler {
         List<String> columnNames = List.of("개발자", "디자이너", "기획자");
         int year = latestRecruitment.getYear();
 
-        if(isExists(columnNames, year)) return;
+        if (isExists(columnNames, year)) return;
 
         List<Columns> commonColumns =
                 columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
@@ -72,10 +72,10 @@ public class RecruitmentRegisteredEventHandler {
         createInvisibleBoards(existColumns);
     }
 
-    private boolean isExists(List<String> columnNames, int year){
+    private boolean isExists(List<String> columnNames, int year) {
         return columnNames.stream()
                 .map(name -> columnLoadPort.existsColumnsByTitle(name, year))
-                .reduce(true, (b1,b2)->b1&&b2);
+                .reduce(true, (b1, b2) -> b1 && b2);
     }
 
     /**

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -59,23 +59,27 @@ public class RecruitmentRegisteredEventHandler {
         List<String> columnNames = List.of("개발자", "디자이너", "기획자");
         int year = latestRecruitment.getYear();
 
-        if (isExists(columnNames, year)) return;
+        columnNames = filterNotExists(columnNames, year);
 
-        List<Columns> commonColumns =
-                columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
+        // 모든 컬럼이 존재하지 않으면
+        if(!columnNames.isEmpty()) {
+            List<Columns> commonColumns =
+                    columnNames.stream().map(name -> Columns.createCommonColumn(name, year)).toList();
 
-        List<Columns> saved = columnRecordPort.saveAll(commonColumns);
+            List<Columns> saved = columnRecordPort.saveAll(commonColumns);
 
-        List<Columns> existColumns = columnLoadPort.getColumnsByNavigationIdAndYear(1, year);
+            List<Columns> existColumns = columnLoadPort.getColumnsByNavigationIdAndYear(1, year);
 
-        connect(existColumns);
-        createInvisibleBoards(existColumns);
+            connect(existColumns);
+            createInvisibleBoards(existColumns);
+        }
     }
 
-    private boolean isExists(List<String> columnNames, int year) {
+    private List<String> filterNotExists(List<String> columnNames, int year) {
         return columnNames.stream()
-                .map(name -> columnLoadPort.existsColumnsByTitle(name, year))
-                .reduce(true, (b1, b2) -> b1 && b2);
+                .filter(name -> !columnLoadPort.existsColumnsByTitle(name, year))
+                .peek(name -> System.out.println(String.format("%s 컬럼 존재", name)))
+                .toList();
     }
 
     /**

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/handler/RecruitmentRegisteredEventHandler.java
@@ -15,8 +15,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Component
@@ -33,6 +36,7 @@ public class RecruitmentRegisteredEventHandler {
     private final BoardLoadPort boardLoadPort;
     private final BoardRecordPort boardRecordPort;
 
+    @Async
     @Transactional
     @EventListener(RecruitmentRegistered.class)
     public void handle(RecruitmentRegistered event) {

--- a/server/Recruit-Api/src/test/java/com/econovation/recruit/columns/ColumnTest.java
+++ b/server/Recruit-Api/src/test/java/com/econovation/recruit/columns/ColumnTest.java
@@ -1,0 +1,72 @@
+package com.econovation.recruit.columns;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.econovation.recruit.api.card.util.ColumnsUtil;
+import com.econovation.recruitdomain.domains.board.domain.Columns;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ColumnTest {
+
+    private List<Columns> fixture;
+
+    @BeforeEach
+    void init(){
+        // 테스트용 fixture 객체 초기화
+        fixture = new ArrayList<>(10);
+        for(int i=1; i<=10; i++){
+            Columns columns = Columns.builder().id(i).title("test"+i).year(0).navigationId(0).build();
+            fixture.add(columns);
+        }
+    }
+
+    @Test
+    @DisplayName("connectAll을 호출하면 연결이 끊긴 컬럼없이 모두 연결된다.")
+    void columnsUtilTest(){
+        ColumnsUtil.connectAll(fixture);
+
+        long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+
+        assertEquals(nullCnt, 1);
+    }
+
+    @Test
+    @DisplayName("connectAll 호출 전과 후의 nextColumnId가 null인 개수는 다르다.")
+    void columnUtilTest2(){
+
+        assertAll(
+                () -> {
+                    long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+                    assertEquals(nullCnt, fixture.size());
+                    },
+                () -> {
+                    ColumnsUtil.connectAll(fixture);
+                    long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+                    assertEquals(nullCnt, 1);
+                });
+
+    }
+
+    @Test
+    @DisplayName("findNextColumnsIdIsNull은 nextColumnsId가 null인 가장 처음의 인덱스를 반환한다.")
+    void columnsUtilTest3(){
+        assertAll(
+                () -> {
+                    int idx = ColumnsUtil.findNextColumnIdIsNull(fixture);
+                    assertEquals(idx, 0);
+                },
+                () -> {
+                    ColumnsUtil.connectAll(fixture);
+                    int idx = ColumnsUtil.findNextColumnIdIsNull(fixture);
+                    assertEquals(idx, fixture.size()-1);
+                }
+        );
+    }
+
+
+}

--- a/server/Recruit-Api/src/test/java/com/econovation/recruit/columns/ColumnTest.java
+++ b/server/Recruit-Api/src/test/java/com/econovation/recruit/columns/ColumnTest.java
@@ -16,45 +16,47 @@ public class ColumnTest {
     private List<Columns> fixture;
 
     @BeforeEach
-    void init(){
+    void init() {
         // 테스트용 fixture 객체 초기화
         fixture = new ArrayList<>(10);
-        for(int i=1; i<=10; i++){
-            Columns columns = Columns.builder().id(i).title("test"+i).year(0).navigationId(0).build();
+        for (int i = 1; i <= 10; i++) {
+            Columns columns =
+                    Columns.builder().id(i).title("test" + i).year(0).navigationId(0).build();
             fixture.add(columns);
         }
     }
 
     @Test
     @DisplayName("connectAll을 호출하면 연결이 끊긴 컬럼없이 모두 연결된다.")
-    void columnsUtilTest(){
+    void columnsUtilTest() {
         ColumnsUtil.connectAll(fixture);
 
-        long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+        long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId() == null).count();
 
         assertEquals(nullCnt, 1);
     }
 
     @Test
     @DisplayName("connectAll 호출 전과 후의 nextColumnId가 null인 개수는 다르다.")
-    void columnUtilTest2(){
+    void columnUtilTest2() {
 
         assertAll(
                 () -> {
-                    long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+                    long nullCnt =
+                            fixture.stream().filter(c -> c.getNextColumnsId() == null).count();
                     assertEquals(nullCnt, fixture.size());
-                    },
+                },
                 () -> {
                     ColumnsUtil.connectAll(fixture);
-                    long nullCnt = fixture.stream().filter(c -> c.getNextColumnsId()==null).count();
+                    long nullCnt =
+                            fixture.stream().filter(c -> c.getNextColumnsId() == null).count();
                     assertEquals(nullCnt, 1);
                 });
-
     }
 
     @Test
     @DisplayName("findNextColumnsIdIsNull은 nextColumnsId가 null인 가장 처음의 인덱스를 반환한다.")
-    void columnsUtilTest3(){
+    void columnsUtilTest3() {
         assertAll(
                 () -> {
                     int idx = ColumnsUtil.findNextColumnIdIsNull(fixture);
@@ -63,10 +65,7 @@ public class ColumnTest {
                 () -> {
                     ColumnsUtil.connectAll(fixture);
                     int idx = ColumnsUtil.findNextColumnIdIsNull(fixture);
-                    assertEquals(idx, fixture.size()-1);
-                }
-        );
+                    assertEquals(idx, fixture.size() - 1);
+                });
     }
-
-
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
@@ -42,6 +42,11 @@ public class ColumnAdaptor implements ColumnRecordPort, ColumnLoadPort {
     }
 
     @Override
+    public boolean existsColumnsByTitle(String title, int year) {
+        return columnRepository.existsByTitleAndYear(title, year);
+    }
+
+    @Override
     public List<Columns> getColumnsByNavigationId(Integer navigationId) {
         List<Columns> byNavigationId = columnRepository.findByNavigationId(navigationId);
         if (byNavigationId.isEmpty()) {

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Board.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Board.java
@@ -43,14 +43,14 @@ public class Board extends BaseTimeEntity {
         this.columnId = columnId;
     }
 
-
     /**
      * columnId와 navigationId를 받아서 Invisible Board 반환
+     *
      * @param columnId
      * @param navigationId
      * @return
      */
-    public static Board creatInvisibleBoard(int columnId, int navigationId){
+    public static Board creatInvisibleBoard(int columnId, int navigationId) {
         return Board.builder()
                 .cardId(null)
                 .nextBoardId(null)

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Board.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Board.java
@@ -42,4 +42,21 @@ public class Board extends BaseTimeEntity {
     public void updateColumnId(@Nullable Integer columnId) {
         this.columnId = columnId;
     }
+
+
+    /**
+     * columnId와 navigationId를 받아서 Invisible Board 반환
+     * @param columnId
+     * @param navigationId
+     * @return
+     */
+    public static Board creatInvisibleBoard(int columnId, int navigationId){
+        return Board.builder()
+                .cardId(null)
+                .nextBoardId(null)
+                .columnId(columnId)
+                .navigationId(navigationId)
+                .cardType(CardType.INVISIBLE)
+                .build();
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -16,4 +16,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
     Optional<Columns> findByNextColumnsIdAndNavigationId(Integer nextColLoc, Integer navigationId);
 
     Optional<Columns> findByNextColumnsId(Integer nextColumnsId);
+
+    @Query("SELECT EXISTS (SELECT c FROM Columns c WHERE c.title=:title AND c.year=:year)")
+    boolean existsByTitleAndYear(String name, Integer year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -17,6 +17,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
 
     Optional<Columns> findByNextColumnsId(Integer nextColumnsId);
 
-    @Query("select case when count(c) > 0 then true else false end from Columns c where c.title = :title and c.year = :year ")
+    @Query(
+            "select case when count(c) > 0 then true else false end from Columns c where c.title = :title and c.year = :year ")
     boolean existsByTitleAndYear(String title, Integer year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -17,7 +17,6 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
 
     Optional<Columns> findByNextColumnsId(Integer nextColumnsId);
 
-    // TODO: 쿼리 잘 동작하는지 수정
-    @Query("SELECT EXISTS (SELECT c FROM Columns c WHERE c.title=:title AND c.year=:year)")
-    boolean existsByTitleAndYear(String name, Integer year);
+    @Query("select case when count(c) > 0 then true else false end from Columns c where c.title = :title and c.year = :year ")
+    boolean existsByTitleAndYear(String title, Integer year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -17,6 +17,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
 
     Optional<Columns> findByNextColumnsId(Integer nextColumnsId);
 
+    // TODO: 쿼리 잘 동작하는지 수정
     @Query("SELECT EXISTS (SELECT c FROM Columns c WHERE c.title=:title AND c.year=:year)")
     boolean existsByTitleAndYear(String name, Integer year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Columns.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Columns.java
@@ -43,4 +43,14 @@ public class Columns extends BaseTimeEntity {
     public void updateNextColumnsId(Integer id) {
         this.nextColumnsId = id;
     }
+
+    /**
+     * 공통 Navigation에 있는 컬럼을 생성하므로, navigationId 는 1로 설정됩니다.
+     * @param title
+     * @param year
+     * @return
+     */
+    public static Columns createCommonColumn(String title, int year){
+        return Columns.builder().navigationId(1).title(title).year(year).build();
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Columns.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/Columns.java
@@ -46,11 +46,12 @@ public class Columns extends BaseTimeEntity {
 
     /**
      * 공통 Navigation에 있는 컬럼을 생성하므로, navigationId 는 1로 설정됩니다.
+     *
      * @param title
      * @param year
      * @return
      */
-    public static Columns createCommonColumn(String title, int year){
+    public static Columns createCommonColumn(String title, int year) {
         return Columns.builder().navigationId(1).title(title).year(year).build();
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ColumnLoadPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ColumnLoadPort.java
@@ -13,6 +13,8 @@ public interface ColumnLoadPort {
 
     Optional<Columns> getColumnOptionalByNextColumnsId(Integer nextColId);
 
+    boolean existsColumnsByTitle(String title, int year);
+
     List<Columns> getColumnsByNavigationId(Integer navigationId);
 
     List<Columns> getColumnsByNavigationIdAndYear(Integer navigationId, Integer year);


### PR DESCRIPTION
### 개요
close #363 
현재 상황에서는, 관리자가 Recruitment 를 등록 후에 칸반보드 페이지에 접속하면, 컬럼이 존재하지 않아 에러가 발생합니다.
이를 해결하기 위해서, Recruitment 생성 시 Column을 자동으로 생성하도록 기능을 추가합니다.

###  작업사항
- 관리자가 새로운 모집 생성 시, 모집할 기수에 맞는 `개발자, 디자이너, 기획자` 컬럼을 자동으로 생성되게 추가하였습니다.

- ColumnsUtil 을 추가하여 아래와 같은 함수를 구현하였습니다.
  - 연결이 끊긴 컬럼을 재연결하는 함수
  - 연결이 끊긴 마지막 컬럼의 인덱스를 반환하는 함수

- RecruitmentRegisteredHandler 내부에서 `개발자, 디자이너, 기획자` 컬럼을 생성하도록 로직을 추가하였습니다.

- 장황한 객체 생성 로직을 줄이기위해 Board, Columns 에 static create 함수를 추가하였습니다.

### 변경로직
- 위와 동일합니다.


### reference

- 