### PR TITLE
[BE-141] 지원서 접수 시, 기수에 맞지 않는 컬럼에 보드가 생성되는 오류를 수정합니다.

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
@@ -168,7 +168,7 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
         hopeField = hopeField;
         Integer columnsId = 0;
         Integer year = latestRecruitmentVo.getYear();
-        if (hopeField.equals("개발자") || hopeField.equals("디자이너") || hopeField.equals("기획자") ) {
+        if (hopeField.equals("개발자") || hopeField.equals("디자이너") || hopeField.equals("기획자")) {
             log.info("ApplicantBoard 생성 : {}, applicantId : {}", hopeField, applicantId);
         } else {
             log.info("hopeField = {} 는 적절한 지원 분야가 아닙니다.", hopeField);

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
@@ -167,18 +167,15 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
         //        \"hopeField\" -> hopeField 로 변경
         hopeField = hopeField;
         Integer columnsId = 0;
-        if (hopeField.equals("개발자")) {
-            columnsId = DEVELOPER_COLUMNS_ID;
-        } else if (hopeField.equals("디자이너")) {
-            columnsId = DESIGNER_COLUMNS_ID;
-        } else if (hopeField.equals("기획자")) {
-            columnsId = PLANNER_COLUMNS_ID;
+        Integer year = latestRecruitmentVo.getYear();
+        if (hopeField.equals("개발자") || hopeField.equals("디자이너") || hopeField.equals("기획자") ) {
+            log.info("ApplicantBoard 생성 : {}, applicantId : {}", hopeField, applicantId);
         } else {
             log.info("hopeField = {} 는 적절한 지원 분야가 아닙니다.", hopeField);
             throw InvalidHopeFieldException.EXCEPTION;
         }
 
-        Columns column = columnLoadPort.getColumnByNextColumnsId(columnsId);
+        Columns column = columnLoadPort.getColumnByYearAndTitle(hopeField, year);
         Board board =
                 Board.builder()
                         .cardType(CardType.APPLICANT)

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
@@ -31,7 +31,8 @@ public class ColumnAdaptor implements ColumnRecordPort, ColumnLoadPort {
 
     @Override
     public Columns getColumnByYearAndTitle(String title, Integer year) {
-        return columnRepository.findByTitleAndYear(title, year)
+        return columnRepository
+                .findByTitleAndYear(title, year)
                 .orElseThrow(() -> ColumnsNotFoundException.EXCEPTION);
     }
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/ColumnAdaptor.java
@@ -30,6 +30,12 @@ public class ColumnAdaptor implements ColumnRecordPort, ColumnLoadPort {
     }
 
     @Override
+    public Columns getColumnByYearAndTitle(String title, Integer year) {
+        return columnRepository.findByTitleAndYear(title, year)
+                .orElseThrow(() -> ColumnsNotFoundException.EXCEPTION);
+    }
+
+    @Override
     public Columns getColumnByNextColumnsId(Integer nextColId) {
         return columnRepository
                 .findById(nextColId)

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,7 +12,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
     List<Columns> findByNavigationId(Integer navigationId);
 
     @Query("SELECT c FROM Columns c WHERE c.navigationId = :navigationId AND c.year = :year")
-    List<Columns> findByNavigationIdAndYear(Integer navigationId, Integer year);
+    List<Columns> findByNavigationIdAndYear(@Param("navigationId") Integer navigationId, @Param("year") Integer year);
 
     Optional<Columns> findByNextColumnsIdAndNavigationId(Integer nextColLoc, Integer navigationId);
 
@@ -19,8 +20,8 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
 
     @Query(
             "select case when count(c) > 0 then true else false end from Columns c where c.title = :title and c.year = :year ")
-    boolean existsByTitleAndYear(String title, Integer year);
+    boolean existsByTitleAndYear(@Param("title") String title, @Param("year") Integer year);
 
     @Query("SELECT c FROM Columns c WHERE c.title=:title AND c.year=:year")
-    Optional<Columns> findByTitleAndYear(String title, Integer Year);
+    Optional<Columns> findByTitleAndYear(@Param("title") String title, @Param("year") Integer Year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -12,7 +12,8 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
     List<Columns> findByNavigationId(Integer navigationId);
 
     @Query("SELECT c FROM Columns c WHERE c.navigationId = :navigationId AND c.year = :year")
-    List<Columns> findByNavigationIdAndYear(@Param("navigationId") Integer navigationId, @Param("year") Integer year);
+    List<Columns> findByNavigationIdAndYear(
+            @Param("navigationId") Integer navigationId, @Param("year") Integer year);
 
     Optional<Columns> findByNextColumnsIdAndNavigationId(Integer nextColLoc, Integer navigationId);
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/ColumnRepository.java
@@ -20,4 +20,7 @@ public interface ColumnRepository extends JpaRepository<Columns, Integer> {
     @Query(
             "select case when count(c) > 0 then true else false end from Columns c where c.title = :title and c.year = :year ")
     boolean existsByTitleAndYear(String title, Integer year);
+
+    @Query("SELECT c FROM Columns c WHERE c.title=:title AND c.year=:year")
+    Optional<Columns> findByTitleAndYear(String title, Integer Year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ColumnLoadPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ColumnLoadPort.java
@@ -11,6 +11,8 @@ public interface ColumnLoadPort {
 
     Columns getColumnByNextColumnsId(Integer nextColId);
 
+    Columns getColumnByYearAndTitle(String title, Integer year);
+
     Optional<Columns> getColumnOptionalByNextColumnsId(Integer nextColId);
 
     boolean existsColumnsByTitle(String title, int year);


### PR DESCRIPTION
### 개요
close #issueNumber
- ApplicantRegisterEvent 이벤트 처리 시에, 접수한 지원자의 Card 와 Board 를 생성합니다.
- 하지만, 칸반보드 V2를 적용하면서, 지원서가 접수되었을 때, 현재 모집 기수와 일치하지 않는 컬럼에 Board와 Card 가 생성되고 있었습니다.

###  작업사항
- ApplicantRegisterEventHandler 로직을 수정하여, 지원서 접수 완료 시에 현재 모집 기수에 맞는 Column에 Card와 Board를 생성하도록 수정합니다.


### 변경로직
- 내용을 적어주세요.


### reference

- 