### PR TITLE
[BE-133] year에 해당하는 지원서 전체 삭제 기능 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -180,6 +180,7 @@ public class ApplicantController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
+    @Operation(summary = "year에 해당하는 모든 지원서를 삭제합니다.")
     @DeleteMapping("/applicants/all/{year}")
     public ResponseEntity<String> deleteApplicants(
             @PathVariable("year") Integer year

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -55,7 +55,6 @@ public class ApplicantController {
     private final CommandGateway commandGateway;
     private final ApplicantValidator applicantValidator;
     private final ApplicantCommandUseCase applicantCommandUseCase;
-    private final RecruitmentUseCase applicationManagementUseCase;
     private final LatestRecruitmentVo latestRecruitInfo;
 
     @Operation(summary = "지원자가 지원서를 작성합니다.", description = "반환 값은 생성된 지원자의 ID입니다.")

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -13,7 +13,6 @@ import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
 import com.econovation.recruit.api.applicant.usecase.TimeTableLoadUseCase;
 import com.econovation.recruit.api.applicant.usecase.TimeTableRegisterUseCase;
 import com.econovation.recruit.api.applicant.validate.ApplicantValidator;
-import com.econovation.recruit.api.recruitment.usecase.RecruitmentUseCase;
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitcommon.annotation.TimeTrace;
@@ -22,7 +21,6 @@ import com.econovation.recruitdomain.domains.applicant.dto.TimeTableVo;
 import com.econovation.recruitdomain.domains.dto.EmailSendDto;
 import com.econovation.recruitdomain.domains.timetable.domain.TimeTable;
 import com.econovation.recruitinfrastructure.apache.CommonsEmailSender;
-import feign.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
@@ -30,13 +28,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import javax.annotation.PostConstruct;
-import javax.persistence.criteria.CriteriaBuilder.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.springdoc.api.annotations.ParameterObject;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -182,9 +177,7 @@ public class ApplicantController {
 
     @Operation(summary = "year에 해당하는 모든 지원서를 삭제합니다.")
     @DeleteMapping("/applicants/all/{year}")
-    public ResponseEntity<String> deleteApplicants(
-            @PathVariable("year") Integer year
-    ) {
+    public ResponseEntity<String> deleteApplicants(@PathVariable("year") Integer year) {
         applicantCommandUseCase.deleteByYear(year);
         return new ResponseEntity<>(APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
     }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -180,11 +180,11 @@ public class ApplicantController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @DeleteMapping("/applicants/all")
+    @DeleteMapping("/applicants/all/{year}")
     public ResponseEntity<String> deleteApplicants(
             @PathVariable("year") Integer year
     ) {
-        applicantCommandUseCase.deleteByyear(year);
+        applicantCommandUseCase.deleteByYear(year);
         return new ResponseEntity<>(APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -1,5 +1,6 @@
 package com.econovation.recruit.api.applicant.controller;
 
+import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE;
 import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANT_SUCCESS_REGISTER_MESSAGE;
 import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
 
@@ -21,6 +22,7 @@ import com.econovation.recruitdomain.domains.applicant.dto.TimeTableVo;
 import com.econovation.recruitdomain.domains.dto.EmailSendDto;
 import com.econovation.recruitdomain.domains.timetable.domain.TimeTable;
 import com.econovation.recruitinfrastructure.apache.CommonsEmailSender;
+import feign.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.PostConstruct;
+import javax.persistence.criteria.CriteriaBuilder.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.axonframework.commandhandling.gateway.CommandGateway;
@@ -176,5 +179,13 @@ public class ApplicantController {
         List<GetApplicantsStatusResponse> result =
                 applicantQueryUseCase.getApplicantsStatus(year, sortType);
         return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/applicants/all")
+    public ResponseEntity<String> deleteApplicants(
+            @PathVariable("year") Integer year
+    ) {
+        applicantCommandUseCase.deleteByyear(year);
+        return new ResponseEntity<>(APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/handler/ApplicantRegisterEventConfirmEmailHandler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/handler/ApplicantRegisterEventConfirmEmailHandler.java
@@ -38,6 +38,9 @@ public class ApplicantRegisterEventConfirmEmailHandler {
         int year = latestRecruitInfo.getYear();
         LocalDateTime passedDate = LocalDateTime.parse(confirmRegisterEmail);
         commonsEmailSender.send(
-                applicantRegistEvent.getEmail(), applicantRegistEvent.getApplicantId(), year, passedDate);
+                applicantRegistEvent.getEmail(),
+                applicantRegistEvent.getApplicantId(),
+                year,
+                passedDate);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -10,6 +10,7 @@ import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerAdaptor
 import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantRegisterEvent;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantStateModifyEvent;
+import com.econovation.recruitdomain.domains.label.adaptor.LabelAdaptor;
 import com.econovation.recruitdomain.domains.score.adaptor.ScoreAdaptor;
 import com.econovation.recruitdomain.domains.timetable.adaptor.TimeTableAdapter;
 import java.util.List;
@@ -28,6 +29,7 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
     private final AnswerAdaptor answerAdaptor;
     private final TimeTableAdapter timeTableAdapter;
     private final ScoreAdaptor scoreAdaptor;
+    private final LabelAdaptor labelAdaptor;
 
     @Override
     @Transactional
@@ -84,7 +86,7 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
         scoreAdaptor.deleteAllByApplicantIds(applicantIds);
 
         // TODO: 지원자 id 리스트를 가지고 label 데이터 삭제하기
-
+        labelAdaptor.deleteAllByApplicantIds(applicantIds);
 
         // TODO: card 테이블에서 지원자 id 리스트에 대응하는 board_id 조회하기
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -4,11 +4,15 @@ import com.econovation.recruit.api.applicant.handler.ApplicantStateUpdateEventHa
 import com.econovation.recruit.api.applicant.usecase.ApplicantCommandUseCase;
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitdomain.common.aop.domainEvent.Events;
+import com.econovation.recruitdomain.domains.applicant.adaptor.AnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantRegisterEvent;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantStateModifyEvent;
+import com.econovation.recruitdomain.domains.score.adaptor.ScoreAdaptor;
+import com.econovation.recruitdomain.domains.timetable.adaptor.TimeTableAdapter;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +22,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AnswerCommandService implements ApplicantCommandUseCase {
-    private final MongoAnswerAdaptor answerAdaptor;
+    private final MongoAnswerAdaptor mongoAnswerAdaptor;
     private final ApplicantStateUpdateEventHandler applicantStateUpdateEventHandler;
     private final LatestRecruitmentVo latestRecruitInfo;
+    private final AnswerAdaptor answerAdaptor;
+    private final TimeTableAdapter timeTableAdapter;
+    private final ScoreAdaptor scoreAdaptor;
 
     @Override
     @Transactional
@@ -51,7 +58,7 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
                         .build();
         //        학번으로 중복 체크
         //        validateRegisterApplicant(qna);
-        answerAdaptor.save(answer);
+        mongoAnswerAdaptor.save(answer);
 
         String name = qna.get("name").toString();
         String hopeField = qna.get("field").toString();
@@ -64,7 +71,26 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
     }
 
     @Override
+    @Transactional
     public void deleteByYear(Integer year) {
-        answerAdaptor.delete(year);
+        // TODO: year에 해당하는 지원자 id 리스트로 뽑기
+        List<String> applicantIds = answerAdaptor.findApplicantIdsByYear(year);
+        System.out.println(applicantIds);
+        mongoAnswerAdaptor.delete(year);
+        // TODO: 지원자 id 리스트를 가지고 time_table 데이터 삭제하기 delete(List<String> applicantIds, Integer year)
+        timeTableAdapter.deleteAllByApplicantIds(applicantIds);
+
+        // TODO: 지원자 id 리스트를 가지고 score 데이터 삭제하기
+        scoreAdaptor.deleteAllByApplicantIds(applicantIds);
+
+        // TODO: 지원자 id 리스트를 가지고 label 데이터 삭제하기
+
+
+        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 board_id 조회하기
+
+        // TODO: 이전에서 조회한 board_id 리스트에 대응하는 board 데이터 삭제하기
+
+        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 데이터 삭제하기
+
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -12,7 +12,6 @@ import com.econovation.recruitdomain.domains.applicant.event.domainevent.Applica
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,5 +61,10 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
                 ApplicantRegisterEvent.of(answer.getId(), name, hopeField, email);
         Events.raise(applicantRegisterEvent);
         return null;
+    }
+
+    @Override
+    public void deleteByYear(Integer year) {
+        answerAdaptor.delete(year);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -10,6 +10,8 @@ import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerAdaptor
 import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantRegisterEvent;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantStateModifyEvent;
+import com.econovation.recruitdomain.domains.board.adaptor.BoardAdaptor;
+import com.econovation.recruitdomain.domains.card.adaptor.CardAdaptor;
 import com.econovation.recruitdomain.domains.label.adaptor.LabelAdaptor;
 import com.econovation.recruitdomain.domains.score.adaptor.ScoreAdaptor;
 import com.econovation.recruitdomain.domains.timetable.adaptor.TimeTableAdapter;
@@ -30,6 +32,8 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
     private final TimeTableAdapter timeTableAdapter;
     private final ScoreAdaptor scoreAdaptor;
     private final LabelAdaptor labelAdaptor;
+    private final CardAdaptor cardAdaptor;
+    private final BoardAdaptor boardAdaptor;
 
     @Override
     @Transactional
@@ -75,24 +79,15 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
     @Override
     @Transactional
     public void deleteByYear(Integer year) {
-        // TODO: year에 해당하는 지원자 id 리스트로 뽑기
         List<String> applicantIds = answerAdaptor.findApplicantIdsByYear(year);
-        System.out.println(applicantIds);
         mongoAnswerAdaptor.delete(year);
-        // TODO: 지원자 id 리스트를 가지고 time_table 데이터 삭제하기 delete(List<String> applicantIds, Integer year)
+
         timeTableAdapter.deleteAllByApplicantIds(applicantIds);
-
-        // TODO: 지원자 id 리스트를 가지고 score 데이터 삭제하기
         scoreAdaptor.deleteAllByApplicantIds(applicantIds);
-
-        // TODO: 지원자 id 리스트를 가지고 label 데이터 삭제하기
         labelAdaptor.deleteAllByApplicantIds(applicantIds);
 
-        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 board_id 조회하기
-
-        // TODO: 이전에서 조회한 board_id 리스트에 대응하는 board 데이터 삭제하기
-
-        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 데이터 삭제하기
-
+        List<Long> cardIds = cardAdaptor.findAllByApplicantIds(applicantIds);
+        boardAdaptor.deleteAllByCardIds(cardIds);
+        cardAdaptor.deleteAllByApplicantIds(applicantIds);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.messaging.responsetypes.ResponseTypes;
 import org.axonframework.queryhandling.QueryGateway;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantCommandUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantCommandUseCase.java
@@ -11,4 +11,6 @@ public interface ApplicantCommandUseCase {
     String execute(String applicantId, String state);
 
     UUID execute(Map<String, Object> blocks, UUID id);
+
+    void deleteByYear(Integer year);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -87,6 +87,8 @@ public class SecurityConfig {
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
                 .mvcMatchers(HttpMethod.POST, "/api/v1/recruitment")
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
+                .mvcMatchers(HttpMethod.DELETE, "/api/v1/applicants/all/*")
+                .hasAnyRole("ROLE_OPERATION")
                 .anyRequest()
                 .hasAnyRole(RolePattern);
 

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/controller/EmailController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/controller/EmailController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/service/ApplicantEmailService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/service/ApplicantEmailService.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/service/FinalEmailDiscussionEmailScheduler.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/email/service/FinalEmailDiscussionEmailScheduler.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/sms/service/ApplicantSmsService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/sms/service/ApplicantSmsService.java
@@ -8,7 +8,6 @@ import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/AnswerMongoDBMigration.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/utils/AnswerMongoDBMigration.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
+++ b/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
@@ -65,6 +65,7 @@ public class RecruitStatic {
     public static final String COMMENT_SUCCESS_UPDATE_MESSAGE = "성공적으로 댓글이 수정됐습니다";
     public static final String WORK_CARD_SUCCESS_UPDATE_MESSAGE = "성공적으로 업무카드가 수정됐습니다";
     public static final List<String> TIMETABLE_APPLICANT_FIELD = List.of("field", "name");
+    public static String APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE = "성공적으로 year에 해당하는 전체 지원서가 삭제되었습니다";
 
     public static final String LOGOUT_SUCCESS_MESSAGE = "성공적으로 로그아웃 됐습니다";
 

--- a/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
+++ b/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
@@ -65,7 +65,8 @@ public class RecruitStatic {
     public static final String COMMENT_SUCCESS_UPDATE_MESSAGE = "성공적으로 댓글이 수정됐습니다";
     public static final String WORK_CARD_SUCCESS_UPDATE_MESSAGE = "성공적으로 업무카드가 수정됐습니다";
     public static final List<String> TIMETABLE_APPLICANT_FIELD = List.of("field", "name");
-    public static String APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE = "성공적으로 year에 해당하는 전체 지원서가 삭제되었습니다";
+    public static String APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE =
+            "성공적으로 year에 해당하는 전체 지원서가 삭제되었습니다";
 
     public static final String LOGOUT_SUCCESS_MESSAGE = "성공적으로 로그아웃 됐습니다";
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -200,8 +200,6 @@ public class AnswerAdaptor {
         query.fields().include("id");
 
         List<MongoAnswer> answers = mongoTemplate.find(query, MongoAnswer.class);
-        return answers.stream()
-                .map(MongoAnswer::getId)
-                .toList();
+        return answers.stream().map(MongoAnswer::getId).toList();
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -194,4 +194,14 @@ public class AnswerAdaptor {
         MongoAnswer result = mongoTemplate.findOne(query, MongoAnswer.class);
         return Optional.ofNullable(result);
     }
+
+    public List<String> findApplicantIdsByYear(Integer year) {
+        Query query = new Query().addCriteria(Criteria.where("year").is(year));
+        query.fields().include("id");
+
+        List<MongoAnswer> answers = mongoTemplate.find(query, MongoAnswer.class);
+        return answers.stream()
+                .map(MongoAnswer::getId)
+                .toList();
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
@@ -39,6 +39,21 @@ public class MongoAnswerAdaptor {
     }
 
     public void delete(Integer year) {
+        // TODO: year에 해당하는 지원자 id 리스트로 뽑기
+
         mongoAnswerRepository.deleteByYear(year);
+        // TODO: 지원자 id 리스트를 가지고 time_table 데이터 삭제하기 delete(List<String> applicantIds, Integer year)
+
+        // TODO: 지원자 id 리스트를 가지고 score 데이터 삭제하기
+
+        // TODO: 지원자 id 리스트를 가지고 label 데이터 삭제하기
+
+
+        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 board_id 조회하기
+
+        // TODO: 이전에서 조회한 board_id 리스트에 대응하는 board 데이터 삭제하기
+
+        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 데이터 삭제하기
+
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
@@ -37,4 +37,8 @@ public class MongoAnswerAdaptor {
         query.addCriteria(Criteria.where("qna.classOf").is(studentId).and("year").is(year));
         return mongoTemplate.exists(query, MongoAnswer.class);
     }
+
+    public void delete(Integer year) {
+        mongoAnswerRepository.deleteByYear(year);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
@@ -39,21 +39,6 @@ public class MongoAnswerAdaptor {
     }
 
     public void delete(Integer year) {
-        // TODO: year에 해당하는 지원자 id 리스트로 뽑기
-
         mongoAnswerRepository.deleteByYear(year);
-        // TODO: 지원자 id 리스트를 가지고 time_table 데이터 삭제하기 delete(List<String> applicantIds, Integer year)
-
-        // TODO: 지원자 id 리스트를 가지고 score 데이터 삭제하기
-
-        // TODO: 지원자 id 리스트를 가지고 label 데이터 삭제하기
-
-
-        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 board_id 조회하기
-
-        // TODO: 이전에서 조회한 board_id 리스트에 대응하는 board 데이터 삭제하기
-
-        // TODO: card 테이블에서 지원자 id 리스트에 대응하는 데이터 삭제하기
-
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerRepository.java
@@ -9,4 +9,5 @@ public interface MongoAnswerRepository extends MongoRepository<MongoAnswer, Stri
 
     //    @Query("{'qna': {$regex: ?0, $options: 'i', $limit: 10}}")
     //    List<MongoAnswer> search(String searchKeyword);
+    void deleteByYear(Integer year);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/BoardAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/BoardAdaptor.java
@@ -86,4 +86,10 @@ public class BoardAdaptor implements BoardLoadPort, BoardRecordPort {
     public void saveAll(List<Board> board) {
         boardRepository.saveAll(board);
     }
+
+    @Override
+    public void deleteAllByCardIds(List<Long> cardIds) {
+        boardRepository.deleteAllByCardIdIn(cardIds);
+    }
+    ;
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/BoardRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/BoardRepository.java
@@ -17,4 +17,6 @@ public interface BoardRepository extends JpaRepository<Board, Integer> {
     List<Board> findByColumnIdIn(List<Integer> columnsIds);
 
     Optional<Board> findByCardId(Long cardId);
+
+    void deleteAllByCardIdIn(List<Long> cardIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/card/adaptor/CardAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/card/adaptor/CardAdaptor.java
@@ -51,4 +51,14 @@ public class CardAdaptor implements CardLoadPort, CardRecordPort {
     public List<Card> findByIdIn(List<Long> cardIds) {
         return cardRepository.findAllById(cardIds);
     }
+
+    @Override
+    public List<Long> findAllByApplicantIds(List<String> applicantIds) {
+        return cardRepository.findAllCardIdByApplicantIdIn(applicantIds);
+    }
+
+    @Override
+    public void deleteAllByApplicantIds(List<String> applicantIds) {
+        cardRepository.deleteAllByApplicantIdIn(applicantIds);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/card/domain/CardRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/card/domain/CardRepository.java
@@ -1,10 +1,18 @@
 package com.econovation.recruitdomain.domains.card.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CardRepository extends JpaRepository<Card, Long> {
     Optional<Card> findByApplicantId(String applicantId);
+
+    @Query("SELECT c.id FROM Card c WHERE c.applicantId IN :applicantIds")
+    List<Long> findAllCardIdByApplicantIdIn(@Param("applicantIds") List<String> applicantIds);
+
+    void deleteAllByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/adaptor/LabelAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/adaptor/LabelAdaptor.java
@@ -83,4 +83,9 @@ public class LabelAdaptor implements LabelRecordPort, LabelLoadPort {
         }
         return labels;
     }
+
+    @Override
+    public void deleteAllByApplicantIds(List<String> applicantIds) {
+            labelRepository.deleteAllByApplicantIdIn(applicantIds);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/adaptor/LabelAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/adaptor/LabelAdaptor.java
@@ -86,6 +86,6 @@ public class LabelAdaptor implements LabelRecordPort, LabelLoadPort {
 
     @Override
     public void deleteAllByApplicantIds(List<String> applicantIds) {
-            labelRepository.deleteAllByApplicantIdIn(applicantIds);
+        labelRepository.deleteAllByApplicantIdIn(applicantIds);
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/domain/LabelRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/label/domain/LabelRepository.java
@@ -23,4 +23,6 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
     @Modifying
     @Query("delete from Label l where l.idpId = :idpId")
     void deleteByIdpId(@Param("idpId") Long idpId);
+
+    void deleteAllByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
@@ -26,7 +26,7 @@ public class RecruitmentAdaptor implements RecruitmentPort {
     public Optional<Recruitment> findLatestOne() {
         List<Recruitment> recruitments = repository.findAllOrderByUpdatedAt();
 
-        if(!recruitments.isEmpty()) {
+        if (!recruitments.isEmpty()) {
             return Optional.ofNullable(recruitments.get(0));
         }
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/score/adaptor/ScoreAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/score/adaptor/ScoreAdaptor.java
@@ -37,4 +37,9 @@ public class ScoreAdaptor implements ScoreLoadPort, ScoreRecordPort {
     public List<Score> findByApplicantIds(List<String> applicantIds) {
         return scoreRepository.findByApplicantIdIn(applicantIds);
     }
+
+    @Override
+    public void deleteAllByApplicantIds(List<String> applicantIds) {
+        scoreRepository.deleteByApplicantIdIn(applicantIds);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/score/domain/ScoreRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/score/domain/ScoreRepository.java
@@ -16,4 +16,6 @@ public interface ScoreRepository extends JpaRepository<Score, Long> {
     @Modifying
     @Query("delete from Score s where s.idpId = :idpId")
     void deleteByIdpId(@Param("idpId") Long idpId);
+
+    void deleteByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
@@ -41,10 +41,10 @@ public class TimeTableAdapter implements TimeTableRecordPort, TimeTableLoadPort 
 
     @Override
     public void deleteAllByApplicantIds(List<String> applicantIds) {
-        List<TimeTable> timeTablesToDelete = applicantIds.stream()
+        List<TimeTable> timeTables = applicantIds.stream()
                 .flatMap(applicantId -> timeTableRepository.findByApplicantId(applicantId).stream())
                 .toList();
 
-        timeTableRepository.deleteAll(timeTablesToDelete);
+        timeTableRepository.deleteAll(timeTables);
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
@@ -41,10 +41,6 @@ public class TimeTableAdapter implements TimeTableRecordPort, TimeTableLoadPort 
 
     @Override
     public void deleteAllByApplicantIds(List<String> applicantIds) {
-        List<TimeTable> timeTables = applicantIds.stream()
-                .flatMap(applicantId -> timeTableRepository.findByApplicantId(applicantId).stream())
-                .toList();
-
-        timeTableRepository.deleteAll(timeTables);
+        timeTableRepository.deleteByApplicantIdIn(applicantIds);
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/adaptor/TimeTableAdapter.java
@@ -38,4 +38,13 @@ public class TimeTableAdapter implements TimeTableRecordPort, TimeTableLoadPort 
         }
         return timeTables;
     }
+
+    @Override
+    public void deleteAllByApplicantIds(List<String> applicantIds) {
+        List<TimeTable> timeTablesToDelete = applicantIds.stream()
+                .flatMap(applicantId -> timeTableRepository.findByApplicantId(applicantId).stream())
+                .toList();
+
+        timeTableRepository.deleteAll(timeTablesToDelete);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/domain/TimeTableRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/domain/TimeTableRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TimeTableRepository extends JpaRepository<TimeTable, Integer> {
     List<TimeTable> findByApplicantId(String applicantId);
+
     void deleteByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/domain/TimeTableRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/timetable/domain/TimeTableRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TimeTableRepository extends JpaRepository<TimeTable, Integer> {
     List<TimeTable> findByApplicantId(String applicantId);
+    void deleteByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/BoardRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/BoardRecordPort.java
@@ -9,4 +9,6 @@ public interface BoardRecordPort {
     void delete(Board board);
 
     void saveAll(List<Board> board);
+
+    void deleteAllByCardIds(List<Long> cardIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CardLoadPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CardLoadPort.java
@@ -12,4 +12,6 @@ public interface CardLoadPort {
     Card findByApplicantId(String applicantId);
 
     List<Card> findByIdIn(List<Long> cardIds);
+
+    List<Long> findAllByApplicantIds(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CardRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CardRecordPort.java
@@ -1,9 +1,12 @@
 package com.econovation.recruitdomain.out;
 
 import com.econovation.recruitdomain.domains.card.domain.Card;
+import java.util.List;
 
 public interface CardRecordPort {
     Card save(Card card);
 
     void delete(Long cardId);
+
+    void deleteAllByApplicantIds(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/LabelRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/LabelRecordPort.java
@@ -14,4 +14,6 @@ public interface LabelRecordPort {
 
     @Query("delete from Label l where l.idpId = :idpId")
     void deleteByInterviewerId(@Param("idpId") Long idpId);
+
+    void deleteAllByApplicantIds(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ScoreRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/ScoreRecordPort.java
@@ -9,4 +9,6 @@ public interface ScoreRecordPort {
     List<Score> save(List<Score> scores);
 
     void deleteByInterviewerId(Long idpId);
+
+    void deleteAllByApplicantIds(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/TimeTableRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/TimeTableRecordPort.java
@@ -7,4 +7,6 @@ public interface TimeTableRecordPort {
     //    List<TimeTableInsertDto> saveAll(List<TimeTableInsertDto> timeTableInsertDtos,Integer
     // applicantId);
     List<TimeTable> saveAll(List<TimeTable> timeTables);
+
+    void deleteAllByApplicantIds(List<String> applicantIds);
 }


### PR DESCRIPTION
### 개요
#355 : 특정 year에 해당하는 모든 지원서를 삭제하는 기능을 구현했습니다.

###  작업사항

year(기수)에 해당하는 지원서 전체 삭제 기능입니다.

절차는 다음과 같습니다.

- mongodb에서 year에 해당하는 applicantId를 리스트로 조회합니다. 이후 `List<String> applicantIds`를 통해 mysql 데이터를 삭제합니다.
- mongodb에서 year에 해당하는 지원서를 모두 삭제합니다.

- 위에서 조회한 applicantIds로 time_table -> label -> score 엔티티 순으로 mysql에서 applicantIds에 해당하는 IN 쿼리를 통해 데이터들을 삭제해주었습니다.

- card와 board 테이블을 삭제하기 위한 작업 순서입니다.
   - 우선 card 테이블에서 applicantIds에 해당하는 card_id를 리스트로 조회합니다. Board 엔티티에는 applicantId를 속성으로 갖지 않으므로 card_id를 통해서 board 테이블 데이터 삭제를 수행할 수 있습니다.
   - 위에서 조회한 `List<Long> cardIds`를 가지고 cardIds에 해당하는 board 테이블에서 데이터 삭제를 수행합니다.
   - 그리고 마지막으로 card 테이블에서 applicantIds에 해당하는 데이터들을 삭제합니다.
   
결론적으로 테이블 삭제 순서는 다음과 같습니다:
mongodb에서 실제 지원서 삭제 -> time_table -> label -> score -> board -> card 

<img width="893" height="525" alt="image" src="https://github.com/user-attachments/assets/71b97bb2-b0a5-4a63-9deb-ed95d81d6210" />


### reference
영우님과 페어프로그래밍 했습니다.