### PR TITLE
[BE-133] 지원서 단일 일괄 삭제 기능 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.applicant.controller;
 
 import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE;
+import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANTS_SUCCESS_DELETE_MESSAGE;
 import static com.econovation.recruitcommon.consts.RecruitStatic.APPLICANT_SUCCESS_REGISTER_MESSAGE;
 import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
 
@@ -17,6 +18,7 @@ import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitcommon.annotation.TimeTrace;
 import com.econovation.recruitcommon.annotation.XssProtected;
+import com.econovation.recruitdomain.domains.applicant.domain.Applicant;
 import com.econovation.recruitdomain.domains.applicant.dto.TimeTableVo;
 import com.econovation.recruitdomain.domains.dto.EmailSendDto;
 import com.econovation.recruitdomain.domains.timetable.domain.TimeTable;
@@ -180,5 +182,14 @@ public class ApplicantController {
     public ResponseEntity<String> deleteApplicants(@PathVariable("year") Integer year) {
         applicantCommandUseCase.deleteByYear(year);
         return new ResponseEntity<>(APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
+    }
+
+    @Operation(summary = "지원서들을 선택해서 일괄 삭제합니다.")
+    @DeleteMapping("/applicants")
+    public ResponseEntity<String> deleteApplicant(
+            @RequestBody List<String> applicantIds
+            ) {
+        applicantCommandUseCase.deleteByApplicantIds(applicantIds);
+        return new ResponseEntity<>(APPLICANTS_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -90,4 +90,10 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
         boardAdaptor.deleteAllByCardIds(cardIds);
         cardAdaptor.deleteAllByApplicantIds(applicantIds);
     }
+
+    @Override
+    @Transactional
+    public void deleteByApplicantIds(List<String> applicantIds) {
+        mongoAnswerAdaptor.deleteByApplicantIds(applicantIds);
+    }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -12,6 +12,7 @@ import com.econovation.recruitdomain.domains.applicant.event.domainevent.Applica
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantStateModifyEvent;
 import com.econovation.recruitdomain.domains.board.adaptor.BoardAdaptor;
 import com.econovation.recruitdomain.domains.board.domain.Board;
+import com.econovation.recruitdomain.domains.board.exception.BoardNotFoundException;
 import com.econovation.recruitdomain.domains.card.adaptor.CardAdaptor;
 import com.econovation.recruitdomain.domains.card.domain.Card;
 import com.econovation.recruitdomain.domains.label.adaptor.LabelAdaptor;
@@ -113,7 +114,7 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
         Card card = cardAdaptor.findByApplicantId(applicantId);
         Board deleteBoard = boardAdaptor.getBoardByCardId(card.getId());
 
-        Board previousBoard = boardAdaptor.getByNextBoardId(deleteBoard.getId()).get();
+        Board previousBoard = boardAdaptor.getByNextBoardId(deleteBoard.getId()).orElseThrow(() -> BoardNotFoundException.EXCEPTION);
         previousBoard.updateNextBoardID(deleteBoard.getNextBoardId());
 
         boardAdaptor.deleteByCardId(card.getId());

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/AnswerCommandService.java
@@ -11,7 +11,9 @@ import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantSta
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantRegisterEvent;
 import com.econovation.recruitdomain.domains.applicant.event.domainevent.ApplicantStateModifyEvent;
 import com.econovation.recruitdomain.domains.board.adaptor.BoardAdaptor;
+import com.econovation.recruitdomain.domains.board.domain.Board;
 import com.econovation.recruitdomain.domains.card.adaptor.CardAdaptor;
+import com.econovation.recruitdomain.domains.card.domain.Card;
 import com.econovation.recruitdomain.domains.label.adaptor.LabelAdaptor;
 import com.econovation.recruitdomain.domains.score.adaptor.ScoreAdaptor;
 import com.econovation.recruitdomain.domains.timetable.adaptor.TimeTableAdapter;
@@ -95,5 +97,25 @@ public class AnswerCommandService implements ApplicantCommandUseCase {
     @Transactional
     public void deleteByApplicantIds(List<String> applicantIds) {
         mongoAnswerAdaptor.deleteByApplicantIds(applicantIds);
+
+        timeTableAdapter.deleteAllByApplicantIds(applicantIds);
+        scoreAdaptor.deleteAllByApplicantIds(applicantIds);
+        labelAdaptor.deleteAllByApplicantIds(applicantIds);
+
+        for (String applicantId : applicantIds) {
+            deleteBoardByApplicantId(applicantId);
+        }
+
+        cardAdaptor.deleteAllByApplicantIds(applicantIds);
+    }
+
+    private void deleteBoardByApplicantId(String applicantId) {
+        Card card = cardAdaptor.findByApplicantId(applicantId);
+        Board deleteBoard = boardAdaptor.getBoardByCardId(card.getId());
+
+        Board previousBoard = boardAdaptor.getByNextBoardId(deleteBoard.getId()).get();
+        previousBoard.updateNextBoardID(deleteBoard.getNextBoardId());
+
+        boardAdaptor.deleteByCardId(card.getId());
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantCommandUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantCommandUseCase.java
@@ -1,6 +1,7 @@
 package com.econovation.recruit.api.applicant.usecase;
 
 import com.econovation.recruitcommon.annotation.UseCase;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -13,4 +14,6 @@ public interface ApplicantCommandUseCase {
     UUID execute(Map<String, Object> blocks, UUID id);
 
     void deleteByYear(Integer year);
+
+    void deleteByApplicantIds(List<String> applicantIds);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
                 .mvcMatchers(HttpMethod.POST, "/api/v1/recruitment")
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
-                .mvcMatchers(HttpMethod.DELETE, "/api/v1/applicants/all/*")
+                .mvcMatchers(HttpMethod.DELETE, "/api/v1/applicants/all/*", "/api/v1/applicants")
                 .hasAnyRole("ROLE_OPERATION")
                 .anyRequest()
                 .hasAnyRole(RolePattern);

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/interviewer/controller/InterviewerController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/interviewer/controller/InterviewerController.java
@@ -52,6 +52,7 @@ public class InterviewerController {
     public ResponseEntity<String> createInterviewers(@RequestBody List<Long> idpIds) {
         interviewerUseCase.createInterviewers(idpIds);
         return new ResponseEntity<>(INTERVIEWER_SUCCESS_REGISTER_MESSAGE, HttpStatus.OK);
+
     }
 
     @DevelopOnlyApi

--- a/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
+++ b/server/Recruit-Common/src/main/java/com/econovation/recruitcommon/consts/RecruitStatic.java
@@ -67,6 +67,7 @@ public class RecruitStatic {
     public static final List<String> TIMETABLE_APPLICANT_FIELD = List.of("field", "name");
     public static String APPLICANTS_BY_YEAR_SUCCESS_DELETE_MESSAGE =
             "성공적으로 year에 해당하는 전체 지원서가 삭제되었습니다";
+    public static String APPLICANTS_SUCCESS_DELETE_MESSAGE = "성공적으로 단일 지원서들을 일괄 삭제했습니다.";
 
     public static final String LOGOUT_SUCCESS_MESSAGE = "성공적으로 로그아웃 됐습니다";
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerAdaptor.java
@@ -41,4 +41,8 @@ public class MongoAnswerAdaptor {
     public void delete(Integer year) {
         mongoAnswerRepository.deleteByYear(year);
     }
+
+    public void deleteByApplicantIds(List<String> applicantIds) {
+        mongoAnswerRepository.deleteByIdIn(applicantIds);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswerRepository.java
@@ -10,4 +10,6 @@ public interface MongoAnswerRepository extends MongoRepository<MongoAnswer, Stri
     //    @Query("{'qna': {$regex: ?0, $options: 'i', $limit: 10}}")
     //    List<MongoAnswer> search(String searchKeyword);
     void deleteByYear(Integer year);
+
+    void deleteByIdIn(List<String> applicantIds);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/BoardAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/adaptor/BoardAdaptor.java
@@ -91,5 +91,9 @@ public class BoardAdaptor implements BoardLoadPort, BoardRecordPort {
     public void deleteAllByCardIds(List<Long> cardIds) {
         boardRepository.deleteAllByCardIdIn(cardIds);
     }
-    ;
+
+    @Override
+    public void deleteByCardId(Long cardId) {
+        boardRepository.deleteByCardId(cardId);
+    }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/BoardRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/board/domain/BoardRepository.java
@@ -19,4 +19,6 @@ public interface BoardRepository extends JpaRepository<Board, Integer> {
     Optional<Board> findByCardId(Long cardId);
 
     void deleteAllByCardIdIn(List<Long> cardIds);
+
+    void deleteByCardId(Long cardId);
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/BoardRecordPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/BoardRecordPort.java
@@ -11,4 +11,6 @@ public interface BoardRecordPort {
     void saveAll(List<Board> board);
 
     void deleteAllByCardIds(List<Long> cardIds);
+
+    void deleteByCardId(Long cardId);
 }


### PR DESCRIPTION
### 개요
close #378 

###  작업사항

지원서를 선택하여 단일 일괄 삭제할 수 있는 기능입니다.

- 요청으로부터 받은 `List<String> applicantIds`에서 applicantIds로 mongodb에서 데이터를 삭제합니다.
- time_table, score, label 테이블에 대한 데이터 삭제는 지원서 전체 삭제 기능과 동일하게 수행되었습니다. `deleteAllByApplicantIds(applicantIds);`
- applicantIds에서 각 applicantId에 대하여 board 데이터를 삭제하고 연결리스트를 이어주는 작업을 수행하였습니다.
   - applicantId를 통해 Card를 조회하고 해당 Card로부터 Board를 조회합니다.
   - 지원서 1,2,3이 있다고 가졍했을 때, 2를 삭제하게 된다면 1의 next_board_id가 3을 가리키도록 합니다. 3은 삭제하려는 2의 next_board_id입니다. 
   - 연결리스트를 수정한 뒤, board 데이터를 삭제합니다. 
- 마지막으로 applicantIds를 가지고 card 테이블에서 데이터를 삭제합니다. 


<img width="739" height="529" alt="image" src="https://github.com/user-attachments/assets/e743c11b-6039-4c74-9ed7-b3b36a2a88a9" />



### reference

- 재륜님과 페어프로그래밍하였습니다. 