### PR TITLE
[BE-143] 지원서의 name 항목에 대하여 앞뒤 공백 제거 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/command/CreateAnswerCommand.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/command/CreateAnswerCommand.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.axonframework.modelling.command.TargetAggregateIdentifier;
 
-@AllArgsConstructor
 @ToString
 @Data
 @NoArgsConstructor
@@ -17,4 +16,20 @@ public class CreateAnswerCommand {
     @TargetAggregateIdentifier private String id;
     private Integer year;
     private Map<String, Object> qna;
+
+    public CreateAnswerCommand(String id, Integer year, Map<String, Object> qna) {
+        this.id = id;
+        this.year = year;
+        setQna(qna);
+    }
+
+    private void setQna(Map<String, Object> qna) {
+        if (qna != null && qna.containsKey("name")) {
+            Object value = qna.get("name");
+            if (value instanceof String str) {
+                qna.put("name", str.trim());
+            }
+        }
+        this.qna = qna;
+    }
 }


### PR DESCRIPTION
### 개요
close #380 

###  작업사항
- 프론트에서 지원서에 대한 데이터를 `Map<String, Object> qna`로 받고 컨트롤러에서 year와의 정보를 총합하여 이벤트 요청 객체인 `CreateAnswerCommand`를 만듭니다.
- 해당 이벤트 요청 객체 내부에서 qna에서 name key에 해당하는 값의 공백을 앞뒤로 제거하였습니다.

### 변경로직
- 지원서의 name의 앞뒤 공백을 제거하고 저장