### PR TITLE
[BE-144] MongoAnswer에서 year와 classOf를 가지고 unique key 설정 

### DIFF
--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswer.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswer.java
@@ -9,11 +9,18 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.TextIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "applicant")
+@CompoundIndexes({
+        @CompoundIndex(name = "unique_class_of_per_year",
+                def = "{'year': 1, 'qna.classOf': 1}",
+                unique = true)
+})
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter


### PR DESCRIPTION
### 개요
close #381 

###  작업사항
- MongoAnswer에서 year와 classOf에 대하여 unqiue 제약 조건을 설정함으로써 중복 지원 저장을 막도록 하였습니다. 

### 변경로직
- year와 classOf가 일치하는 지원서가 저장될 수 없습니다. 