### PR TITLE
[BE-146] 합/불 상태 변경 가능 여부 계산 로직 추가

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -162,10 +162,12 @@ public class ApplicantController {
     }
 
     @Operation(
-            summary = "지원서의 합/불 상태를 조회합니다. (합/불 관리자 페이지 전용)",
+            summary = "지원서의 합/불 상태를 조회합니다.",
             description =
                     """
-                    응답으로 오는 passState 값의 종류는 non-processed, non-passed, first-passed, final-passed 입니다.
+                    - passState : non-processed | non-passed | first-passed | final-passed
+                    - isPassable : 현재 상태에서 pass 할 수 있는지 여부
+                    - isNonPassable : 현재 상태에서 non-pass 할 수 있는지 여부
                     """)
     @GetMapping("/year/{year}/applicants/pass-state")
     public ResponseEntity<List<GetApplicantsStatusResponse>> getApplicantsStatus(

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/ApplicantStateResponse.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/ApplicantStateResponse.java
@@ -1,8 +1,9 @@
 package com.econovation.recruit.api.applicant.dto;
 
-public record ApplicantStateResponse(String passState) {
 
-    public static ApplicantStateResponse of(String passState) {
-        return new ApplicantStateResponse(passState);
+public record ApplicantStateResponse(String passState, boolean isPassable, boolean isNonPassable) {
+
+    public static ApplicantStateResponse of(String passState, boolean isPassable, boolean isNonPassable) {
+        return new ApplicantStateResponse(passState, isPassable, isNonPassable);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/dto/GetApplicantsStatusResponse.java
@@ -3,6 +3,7 @@ package com.econovation.recruit.api.applicant.dto;
 import static com.econovation.recruitcommon.consts.RecruitStatic.PASS_STATE_KEY;
 
 import com.econovation.recruitdomain.domains.applicant.domain.state.ApplicantState;
+import com.econovation.recruitdomain.domains.applicant.domain.state.PeriodStates;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantWrongStateException;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -21,8 +22,12 @@ public class GetApplicantsStatusResponse {
     private Integer year;
     private ApplicantStateResponse state;
 
-    public static GetApplicantsStatusResponse of(Map<String, Object> result) {
+    public static GetApplicantsStatusResponse of(Map<String, Object> result, PeriodStates period) {
         if (result.get(PASS_STATE_KEY) instanceof ApplicantState applicantState) {
+            String passState = applicantState.getPassState();
+            boolean isPassable = applicantState.isPassable(period);
+            boolean isNonPassable = applicantState.isNonPassable(period);
+
             return GetApplicantsStatusResponse.builder()
                     .field((String) result.get("field"))
                     .field1((String) result.get("field1"))
@@ -30,7 +35,7 @@ public class GetApplicantsStatusResponse {
                     .name((String) result.get("name"))
                     .id((String) result.get("id"))
                     .year((Integer) result.get("year"))
-                    .state(ApplicantStateResponse.of(applicantState.getPassState()))
+                    .state(ApplicantStateResponse.of(passState, isPassable, isNonPassable))
                     .build();
         }
         throw ApplicantWrongStateException.wrongStatusException;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -6,12 +6,14 @@ import com.econovation.recruit.api.applicant.aggregate.AnswerAggregate;
 import com.econovation.recruit.api.applicant.dto.AnswersResponseDto;
 import com.econovation.recruit.api.applicant.dto.GetApplicantsStatusResponse;
 import com.econovation.recruit.api.applicant.query.AnswerQuery;
+import com.econovation.recruit.api.applicant.state.support.PeriodCalculator;
 import com.econovation.recruit.api.applicant.usecase.ApplicantQueryUseCase;
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruit.utils.sort.SortHelper;
 import com.econovation.recruit.utils.vo.PageInfo;
 import com.econovation.recruitdomain.domains.applicant.adaptor.AnswerAdaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
+import com.econovation.recruitdomain.domains.applicant.domain.state.PeriodStates;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +32,7 @@ public class ApplicantService implements ApplicantQueryUseCase {
     private final QueryGateway queryGateway;
     private final SortHelper<MongoAnswer> sortHelper;
     private final LatestRecruitmentVo latestRecruitInfo;
+    private final PeriodCalculator periodCalculator;
 
     @Transactional(readOnly = true)
     public Map<String, Object> execute(String answerId) {
@@ -241,7 +244,12 @@ public class ApplicantService implements ApplicantQueryUseCase {
     public List<GetApplicantsStatusResponse> getApplicantsStatus(Integer year, String sortType) {
         List<MongoAnswer> result = answerAdaptor.findByYear(year);
         List<Map<String, Object>> sortedResult = sortAndAddIds(result, sortType);
-        return sortedResult.stream().map(GetApplicantsStatusResponse::of).toList();
+
+        PeriodStates period = periodCalculator.execute();
+
+        return sortedResult.stream()
+                .map(map -> GetApplicantsStatusResponse.of(map, period))
+                .toList();
     }
 
     private List<Map<String, Object>> sortAndAddIds(List<MongoAnswer> result, String sortType) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/validate/ApplicantValidator.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/validate/ApplicantValidator.java
@@ -3,7 +3,7 @@ package com.econovation.recruit.api.applicant.validate;
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitcommon.exception.RecruitCodeException;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerAdaptor;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantDuplicateSubmitException;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantOutOfDateException;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantWrongPositionException;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/quartz/RecruitmentJob.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/quartz/RecruitmentJob.java
@@ -1,7 +1,7 @@
 package com.econovation.recruit.api.recruitment.quartz;
 
 import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import com.econovation.recruitdomain.domains.recruitment.exception.RecruitmentNotFoundException;
 import com.econovation.recruitdomain.out.RecruitmentPort;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/service/RecruitmentService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/service/RecruitmentService.java
@@ -3,7 +3,7 @@ package com.econovation.recruit.api.recruitment.service;
 import com.econovation.recruit.api.recruitment.quartz.RecruitmentScheduler;
 import com.econovation.recruit.api.recruitment.usecase.RecruitmentUseCase;
 import com.econovation.recruitdomain.common.aop.domainEvent.Events;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import com.econovation.recruitdomain.domains.recruitment.event.RecruitmentRegistered;
 import com.econovation.recruitdomain.domains.recruitment.event.RecruitmentTerminated;

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/util/LatestRecruitmentVo.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/util/LatestRecruitmentVo.java
@@ -1,7 +1,7 @@
 package com.econovation.recruit.api.recruitment.util;
 
 import com.econovation.recruitdomain.common.aop.redissonLock.RedissonLock;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import java.time.LocalDateTime;
 import java.util.Objects;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/ApplicantState.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/ApplicantState.java
@@ -18,6 +18,10 @@ public class ApplicantState {
         this.passState = this.passState.nonPass(period);
     }
 
+    public boolean isPassable(PeriodStates period){ return passState.isPassable(period); }
+
+    public boolean isNonPassable(PeriodStates period){ return passState.isNonPassable(period); }
+
     public String getPassState() {
         return this.passState.toString();
     }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/PassStates.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/PassStates.java
@@ -1,6 +1,7 @@
 package com.econovation.recruitdomain.domains.applicant.domain.state;
 
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantWrongStateException;
+import com.econovation.recruitdomain.domains.applicant.exception.NotOperatedException;
 import java.util.Arrays;
 import lombok.Getter;
 
@@ -9,68 +10,121 @@ public enum PassStates {
     NON_PROCESSED("non-processed") {
         @Override
         public PassStates pass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return PassStates.FIRST_PASSED;
+            if (isPassable(period)) return PassStates.FIRST_PASSED;
             else return this;
         }
 
         @Override
         public PassStates nonPass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return PassStates.FIRST_FAILED;
+            if (isNonPassable(period)) return PassStates.FIRST_FAILED;
             else return this;
+        }
+
+        @Override
+        public boolean isPassable(PeriodStates period) {
+            if(period.equals(PeriodStates.FIRST_DISCUSSION)) return true;
+            else return false;
+        }
+
+        @Override
+        public boolean isNonPassable(PeriodStates period) {
+            if(period.equals(PeriodStates.FIRST_DISCUSSION)) return true;
+            else return false;
         }
     },
     FIRST_PASSED("first-passed") {
         @Override
         public PassStates pass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return this;
-            else if (period.equals(PeriodStates.FINAL_DISCUSSION)) return PassStates.FINAL_PASSED;
-            else return PassStates.FINAL_FAILED;
+            if (isPassable(period)) return PassStates.FINAL_PASSED;
+            else throw NotOperatedException.EXCEPTION;
         }
 
         @Override
         public PassStates nonPass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return PassStates.FIRST_FAILED;
-            else if (period.equals(PeriodStates.FINAL_DISCUSSION)) return PassStates.FINAL_FAILED;
-            else return this;
+            if (isNonPassable(period)) {
+                if (period.equals(PeriodStates.FIRST_DISCUSSION))
+                    return PassStates.FIRST_FAILED;
+                else
+                    return PassStates.FINAL_FAILED;
+            }
+
+            else throw NotOperatedException.EXCEPTION;
+        }
+
+        @Override
+        public boolean isPassable(PeriodStates period) {
+            return period.equals(PeriodStates.FINAL_DISCUSSION);
+        }
+
+        @Override
+        public boolean isNonPassable(PeriodStates period) {
+            return period.equals(PeriodStates.FIRST_DISCUSSION) || period.equals(PeriodStates.FINAL_DISCUSSION);
         }
     },
     FIRST_FAILED("first-failed") {
         @Override
         public PassStates pass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return PassStates.FIRST_PASSED;
+            if (isPassable(period)) return PassStates.FIRST_PASSED;
             else return this;
         }
 
         @Override
         public PassStates nonPass(PeriodStates period) {
-            return this;
+            throw NotOperatedException.EXCEPTION;
+        }
+
+        @Override
+        public boolean isPassable(PeriodStates period) {
+            return period.equals(PeriodStates.FIRST_DISCUSSION);
+        }
+
+        @Override
+        public boolean isNonPassable(PeriodStates period) {
+            return false;
         }
     },
     FINAL_PASSED("final-passed") {
         @Override
         public PassStates pass(PeriodStates period) {
-            return this;
+            throw NotOperatedException.EXCEPTION;
         }
 
         @Override
         public PassStates nonPass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION))
-                return this; // 1차 합격자 논의 기간에 최종합격 상태에 대한 요청이 있으면 에러를..?
-            else if (period.equals(PeriodStates.FINAL_DISCUSSION)) return PassStates.FIRST_PASSED;
-            else return this;
+            if (isNonPassable(period)) return PassStates.FINAL_FAILED;
+            else throw NotOperatedException.EXCEPTION;
+        }
+
+        @Override
+        public boolean isPassable(PeriodStates period) {
+            return false;
+        }
+
+        @Override
+        public boolean isNonPassable(PeriodStates period) {
+            return period.equals(PeriodStates.FINAL_DISCUSSION);
         }
     },
     FINAL_FAILED("final-failed") {
         @Override
         public PassStates pass(PeriodStates period) {
-            if (period.equals(PeriodStates.FIRST_DISCUSSION)) return this;
-            else if (period.equals(PeriodStates.FINAL_DISCUSSION)) return PassStates.FIRST_PASSED;
-            else return this;
+            if(isPassable(period)) return PassStates.FINAL_PASSED;
+            else throw NotOperatedException.EXCEPTION;
         }
 
         @Override
         public PassStates nonPass(PeriodStates period) {
-            return this;
+            throw NotOperatedException.EXCEPTION;
+        }
+
+        @Override
+        public boolean isPassable(PeriodStates period) {
+            return period.equals(PeriodStates.FINAL_DISCUSSION);
+        }
+
+        @Override
+        public boolean isNonPassable(PeriodStates period) {
+            return false;
         }
     };
 
@@ -83,6 +137,10 @@ public enum PassStates {
     public abstract PassStates pass(PeriodStates period);
 
     public abstract PassStates nonPass(PeriodStates period);
+
+    public abstract boolean isPassable(PeriodStates period);
+
+    public abstract boolean isNonPassable(PeriodStates period);
 
     public static PassStates findStatus(String state) {
         return Arrays.stream(PassStates.values())

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/PassStates.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/state/PassStates.java
@@ -22,14 +22,12 @@ public enum PassStates {
 
         @Override
         public boolean isPassable(PeriodStates period) {
-            if(period.equals(PeriodStates.FIRST_DISCUSSION)) return true;
-            else return false;
+            return period.equals(PeriodStates.FIRST_DISCUSSION);
         }
 
         @Override
         public boolean isNonPassable(PeriodStates period) {
-            if(period.equals(PeriodStates.FIRST_DISCUSSION)) return true;
-            else return false;
+            return period.equals(PeriodStates.FIRST_DISCUSSION);
         }
     },
     FIRST_PASSED("first-passed") {

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantErrorCode.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantErrorCode.java
@@ -18,8 +18,8 @@ public enum ApplicantErrorCode implements BaseErrorCode {
     APPLICANT_DUPLICATE_SUBMIT(BAD_REQUEST, "APPLICANT_400_1", "이미 지원한 지원자입니다."),
     APPLICANT_PROHIBIT_DELETE(BAD_REQUEST, "APPLICANT_400_2", "지원자를 삭제할 수 없습니다."),
     APPLICANT_WRONG_POSITION(BAD_REQUEST, "APPLICANT_400_3", "디자이너, 개발자, 기획자 중 하나의 포지션을 선택해주세요."),
-    APPLICANT_WRONG_STATE(BAD_REQUEST, "APPLICANT_400_4", "올바른 합/불 상태를 선택해주세요."),
-    NOT_OPERATED(BAD_REQUEST, "APPLICANT_400_5", "상태를 변경할 수 없습니다.");
+    INVALID_STATE_TRANSITION(BAD_REQUEST, "APPLICANT_400_4", "올바른 합/불 상태를 선택해주세요."),
+    CANNOT_CHANGE_STATE(BAD_REQUEST, "APPLICANT_400_5", "상태를 변경할 수 없습니다.");
 
     private Integer status;
     private String code;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantErrorCode.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantErrorCode.java
@@ -18,7 +18,8 @@ public enum ApplicantErrorCode implements BaseErrorCode {
     APPLICANT_DUPLICATE_SUBMIT(BAD_REQUEST, "APPLICANT_400_1", "이미 지원한 지원자입니다."),
     APPLICANT_PROHIBIT_DELETE(BAD_REQUEST, "APPLICANT_400_2", "지원자를 삭제할 수 없습니다."),
     APPLICANT_WRONG_POSITION(BAD_REQUEST, "APPLICANT_400_3", "디자이너, 개발자, 기획자 중 하나의 포지션을 선택해주세요."),
-    APPLICANT_WRONG_STATE(BAD_REQUEST, "APPLICANT_400_4", "올바른 합/불 상태를 선택해주세요.");
+    APPLICANT_WRONG_STATE(BAD_REQUEST, "APPLICANT_400_4", "올바른 합/불 상태를 선택해주세요."),
+    NOT_OPERATED(BAD_REQUEST, "APPLICANT_400_5", "상태를 변경할 수 없습니다.");
 
     private Integer status;
     private String code;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantWrongStateException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/ApplicantWrongStateException.java
@@ -8,6 +8,6 @@ public class ApplicantWrongStateException extends RecruitCodeException {
             new ApplicantWrongStateException();
 
     public ApplicantWrongStateException() {
-        super(ApplicantErrorCode.APPLICANT_WRONG_STATE);
+        super(ApplicantErrorCode.INVALID_STATE_TRANSITION);
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/NotOperatedException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/NotOperatedException.java
@@ -1,0 +1,13 @@
+package com.econovation.recruitdomain.domains.applicant.exception;
+
+import com.econovation.recruitcommon.exception.RecruitCodeException;
+
+public class NotOperatedException extends RecruitCodeException {
+
+    public static NotOperatedException EXCEPTION = new NotOperatedException();
+
+    public NotOperatedException(){
+        super(ApplicantErrorCode.NOT_OPERATED);
+    }
+
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/NotOperatedException.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/exception/NotOperatedException.java
@@ -7,7 +7,7 @@ public class NotOperatedException extends RecruitCodeException {
     public static NotOperatedException EXCEPTION = new NotOperatedException();
 
     public NotOperatedException(){
-        super(ApplicantErrorCode.NOT_OPERATED);
+        super(ApplicantErrorCode.CANNOT_CHANGE_STATE);
     }
 
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/RecruitmentResponseDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/RecruitmentResponseDto.java
@@ -1,6 +1,6 @@
 package com.econovation.recruitdomain.domains.dto;
 
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/adaptor/RecruitmentAdaptor.java
@@ -1,7 +1,7 @@
 package com.econovation.recruitdomain.domains.recruitment.adaptor;
 
 import com.econovation.recruitcommon.annotation.Adaptor;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentRepository;
 import com.econovation.recruitdomain.out.RecruitmentPort;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/Recruitment.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/Recruitment.java
@@ -1,7 +1,6 @@
 package com.econovation.recruitdomain.domains.recruitment.domain;
 
 import com.econovation.recruitdomain.domains.BaseTimeEntity;
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentRepository.java
@@ -1,6 +1,5 @@
 package com.econovation.recruitdomain.domains.recruitment.domain;
 
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentStates.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/recruitment/domain/RecruitmentStates.java
@@ -1,4 +1,4 @@
-package com.econovation.recruitdomain.domains.applicant.domain.state;
+package com.econovation.recruitdomain.domains.recruitment.domain;
 
 public enum RecruitmentStates {
     NON_START,

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/RecruitmentPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/RecruitmentPort.java
@@ -1,6 +1,6 @@
 package com.econovation.recruitdomain.out;
 
-import com.econovation.recruitdomain.domains.applicant.domain.state.RecruitmentStates;
+import com.econovation.recruitdomain.domains.recruitment.domain.RecruitmentStates;
 import com.econovation.recruitdomain.domains.recruitment.domain.Recruitment;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
### 개요
close #385 

###  작업사항
- 상태 변경 기간이 맞지 않아, 상태를 변경할 수 없을 경우 `NotOperatedException` 예외가 발생하도록 수정하였습니다.
- 합/불 상태가 변경이 가능한지 여부를 파악하는 로직을 추가했습니다.
- `/api/v1/year/30/applicants/pass-state?order=newest` API의 응답 결과로 `isPassable`, `isNonPassable` 이 추가되었습니다.

### 변경로직
- PassState 내부에 `isPassable()`, `isNonPassable()` 메소드 추가


### reference

- 