### PR TITLE
[BE-145] 지원자 이름 자동완성 기능

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/controller/ApplicantController.java
@@ -18,7 +18,6 @@ import com.econovation.recruit.api.recruitment.util.LatestRecruitmentVo;
 import com.econovation.recruitcommon.annotation.ApiErrorExceptionsExample;
 import com.econovation.recruitcommon.annotation.TimeTrace;
 import com.econovation.recruitcommon.annotation.XssProtected;
-import com.econovation.recruitdomain.domains.applicant.domain.Applicant;
 import com.econovation.recruitdomain.domains.applicant.dto.TimeTableVo;
 import com.econovation.recruitdomain.domains.dto.EmailSendDto;
 import com.econovation.recruitdomain.domains.timetable.domain.TimeTable;
@@ -36,7 +35,15 @@ import org.axonframework.commandhandling.gateway.CommandGateway;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -191,5 +198,11 @@ public class ApplicantController {
             ) {
         applicantCommandUseCase.deleteByApplicantIds(applicantIds);
         return new ResponseEntity<>(APPLICANTS_SUCCESS_DELETE_MESSAGE, HttpStatus.OK);
+    }
+
+    @Operation(summary = "지원자 검색 시 성함 자동완성")
+    @GetMapping("/applicants/names/{year}")
+    public ResponseEntity<List<String>> getApplicantNames(@PathVariable Integer year, @RequestParam String keyword) {
+        return new ResponseEntity<>(applicantQueryUseCase.autocomplete(year, keyword), HttpStatus.OK);
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/service/ApplicantService.java
@@ -285,4 +285,9 @@ public class ApplicantService implements ApplicantQueryUseCase {
         qna.put(PASS_STATE_KEY, mongoAnswer.getApplicantStateOrDefault());
         return qna;
     }
+
+    @Transactional(readOnly = true)
+    public List<String> autocomplete(Integer year, String keyword) {
+        return answerAdaptor.findApplicantNamesForAutocomplete(year, keyword);
+    }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/usecase/ApplicantQueryUseCase.java
@@ -55,4 +55,6 @@ public interface ApplicantQueryUseCase {
             List<String> requestedQnaFields);
 
     Map<String, Object> executeFiltered(String applicantId, List<String> requestedQnaFields);
+
+    List<String> autocomplete(Integer year, String keyword);
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig {
                 .hasAnyRole("ROLE_OPERATION", "ROLE_PRESIDENT")
                 .mvcMatchers(HttpMethod.DELETE, "/api/v1/applicants/all/*", "/api/v1/applicants")
                 .hasAnyRole("ROLE_OPERATION")
+                .mvcMatchers(HttpMethod.GET, "/api/v1/applicants/names/**")
+                .hasAnyRole(RolePattern)
                 .anyRequest()
                 .hasAnyRole(RolePattern);
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/adaptor/AnswerAdaptor.java
@@ -6,8 +6,11 @@ import com.econovation.recruitcommon.annotation.Adaptor;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswer;
 import com.econovation.recruitdomain.domains.applicant.domain.MongoAnswerRepository;
 import com.econovation.recruitdomain.domains.applicant.exception.ApplicantNotFoundException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +28,8 @@ public class AnswerAdaptor {
 
     private final MongoTemplate mongoTemplate;
     private final MongoAnswerRepository answerRepository;
+
+    private static final int AUTOCOMPLETE_LIMIT = 10;
 
     public void save(MongoAnswer answer) {
         answerRepository.save(answer);
@@ -201,5 +206,41 @@ public class AnswerAdaptor {
 
         List<MongoAnswer> answers = mongoTemplate.find(query, MongoAnswer.class);
         return answers.stream().map(MongoAnswer::getId).toList();
+    }
+
+    public List<String> findApplicantNamesForAutocomplete(Integer year, String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return List.of();
+        }
+
+        String escapedKeyword = Pattern.quote(keyword);
+
+        Query query = new Query()
+                .addCriteria(Criteria.where("year").is(year)
+                        .and("qna.name").regex(escapedKeyword, "i"))
+                .limit(AUTOCOMPLETE_LIMIT * 3);
+
+        query.fields().include("qna.name");
+
+        return mongoTemplate.find(query, MongoAnswer.class)
+                .stream()
+                .map(this::extractName)
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted(sort(keyword))
+                .limit(AUTOCOMPLETE_LIMIT)
+                .toList();
+    }
+
+    private Comparator<String> sort(String keyword) {
+        String lower = keyword.toLowerCase();
+        return Comparator
+                .comparing((String name) -> !name.toLowerCase().startsWith(lower))
+                .thenComparing(String::length)
+                .thenComparing(String.CASE_INSENSITIVE_ORDER);
+    }
+
+    private String extractName(MongoAnswer answer) {
+        return (String) answer.getQna().get("name");
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswer.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/applicant/domain/MongoAnswer.java
@@ -17,9 +17,15 @@ import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "applicant")
 @CompoundIndexes({
-        @CompoundIndex(name = "unique_class_of_per_year",
+        @CompoundIndex(
+                name = "unique_class_of_per_year",
                 def = "{'year': 1, 'qna.classOf': 1}",
-                unique = true)
+                unique = true
+        ),
+        @CompoundIndex(
+                name = "idx_year_name",
+                def = "{'year': 1, 'name': 1}"
+        )
 })
 @AllArgsConstructor
 @NoArgsConstructor
@@ -34,6 +40,9 @@ public class MongoAnswer extends MongoBaseTimeEntity {
 
     @Field("year")
     private Integer year;
+
+    @Field("name")
+    private String name;
 
     // shemaless
     @Field("qna")
@@ -70,6 +79,7 @@ public class MongoAnswer extends MongoBaseTimeEntity {
         this.id = id;
         this.year = year;
         this.qna = qna;
+        this.name = String.valueOf(qna.get("name"));
         this.applicantState = new ApplicantState();
         this.qnaSearchIndex =
                 qna.values().stream().map(Object::toString).collect(Collectors.joining(" "));


### PR DESCRIPTION
### 개요
close #384 

###  작업사항
`면접기록`과 `지원현황` 페이지 상단 지원자 이름 검색 시 자동완성 기능을 구현했습니다. 
- 입력한 키워드에 대해서 mongodb에서 조회 후 이름만 추출하여
- prefix -> 이름 길이 -> 사전순으로 정렬

### reference
- `Aho-Corasick 알고리즘`, Trie 구조 기반 등등을 생각해보았는데 저희 데이터가 많지 않아 별도의 인메모리 자료구조를 유지하는 것은 과하다는 생각이 들어 DB 기반 검색으로 구현했습니다. 