### PR TITLE
[BE-148] 코멘트 숨김 기능

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/controller/CommentController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/controller/CommentController.java
@@ -50,7 +50,7 @@ public class CommentController {
         return new ResponseEntity(comments, HttpStatus.OK);
     }
 
-    @Operation(summary = "applicationId로 댓글 조회")
+    @Operation(summary = "applicationId로 댓글 조회", description = "권한별로 회장단만 모든 코멘트 조회 가능, TF들은 자신의 코멘트만 조회 가능")
     @GetMapping("/applicants/{applicant-id}/comments")
     public ResponseEntity<List<CommentPairVo>> findByApplicantId(
             @PathVariable(name = "applicant-id") String applicantId) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/service/CommentService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/service/CommentService.java
@@ -166,14 +166,16 @@ public class CommentService implements CommentUseCase {
     @Override
     public List<CommentPairVo> findByCardId(Long cardId) {
         Long idpId = SecurityUtils.getCurrentUserId();
+        Interviewer interviewer = interviewerLoadPort.loadInterviewById(idpId);
+
         Card card = cardLoadPort.findById(cardId);
         List<Comment> comments = commentLoadPort.findByCardId(card.getId());
 
-        return getCommentPairVo(idpId, comments);
+        return getCommentPairVo(idpId, comments, isAdminRole(interviewer));
     }
 
     @NotNull
-    private List<CommentPairVo> getCommentPairVo(Long idpId, List<Comment> comments) {
+    private List<CommentPairVo> getCommentPairVo(Long idpId, List<Comment> comments, boolean isAdmin) {
         List<Long> idpIds = comments.stream().map(Comment::getIdpId).collect(Collectors.toList());
 
         List<Interviewer> interviewers = interviewerLoadPort.loadInterviewerByIdpIds(idpIds);
@@ -195,6 +197,7 @@ public class CommentService implements CommentUseCase {
                                                                             .equals(idpId));
 
                             Boolean canEdit = Objects.equals(comment.getIdpId(), idpId);
+                            Boolean isBlurred = !isAdmin && !canEdit;
                             String interviewersName =
                                     interviewers.stream()
                                             .filter(
@@ -205,7 +208,7 @@ public class CommentService implements CommentUseCase {
                                             .findFirst()
                                             .map(Interviewer::getName)
                                             .orElse("");
-                            return CommentPairVo.of(comment, isLiked, interviewersName, canEdit);
+                            return CommentPairVo.of(comment, isLiked, interviewersName, canEdit, isBlurred);
                         })
                 .collect(Collectors.toList());
     }
@@ -233,15 +236,9 @@ public class CommentService implements CommentUseCase {
     public List<CommentPairVo> findByApplicantId(String applicantId) {
         Long idpId = SecurityUtils.getCurrentUserId();
         Interviewer interviewer = interviewerLoadPort.loadInterviewById(idpId);
-        List<Comment> comments;
-        if (interviewer.getRole() == Role.ROLE_OPERATION
-                || interviewer.getRole() == Role.ROLE_PRESIDENT) {
-            comments = commentLoadPort.findByApplicantId(applicantId);
-        } else {
-            comments = commentLoadPort.findByApplicantIdAndIdpId(applicantId, idpId);
-        }
+        List<Comment> comments = commentLoadPort.findByApplicantId(applicantId);
 
-        return getCommentPairVo(idpId, comments);
+        return getCommentPairVo(idpId, comments, isAdminRole(interviewer));
     }
 
     @Override
@@ -255,5 +252,10 @@ public class CommentService implements CommentUseCase {
         commentLikeRecordPort.deleteAll(
                 commentLikeLoadPort.findByCommentIds(
                         comments.stream().map(Comment::getId).collect(Collectors.toList())));
+    }
+
+    private boolean isAdminRole(Interviewer interviewer) {
+        return interviewer.getRole() == Role.ROLE_OPERATION
+                || interviewer.getRole() == Role.ROLE_PRESIDENT;
     }
 }

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/service/CommentService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/comment/service/CommentService.java
@@ -12,6 +12,7 @@ import com.econovation.recruitdomain.domains.comment.exception.CommentNotHostExc
 import com.econovation.recruitdomain.domains.dto.CommentPairVo;
 import com.econovation.recruitdomain.domains.dto.CommentRegisterDto;
 import com.econovation.recruitdomain.domains.interviewer.domain.Interviewer;
+import com.econovation.recruitdomain.domains.interviewer.domain.Role;
 import com.econovation.recruitdomain.out.CardLoadPort;
 import com.econovation.recruitdomain.out.CommentLikeLoadPort;
 import com.econovation.recruitdomain.out.CommentLikeRecordPort;
@@ -227,12 +228,19 @@ public class CommentService implements CommentUseCase {
         comment.updateContent(content);
     }
 
-    //
     @Override
     @Transactional(readOnly = true)
     public List<CommentPairVo> findByApplicantId(String applicantId) {
         Long idpId = SecurityUtils.getCurrentUserId();
-        List<Comment> comments = commentLoadPort.findByApplicantId(applicantId);
+        Interviewer interviewer = interviewerLoadPort.loadInterviewById(idpId);
+        List<Comment> comments;
+        if (interviewer.getRole() == Role.ROLE_OPERATION
+                || interviewer.getRole() == Role.ROLE_PRESIDENT) {
+            comments = commentLoadPort.findByApplicantId(applicantId);
+        } else {
+            comments = commentLoadPort.findByApplicantIdAndIdpId(applicantId, idpId);
+        }
+
         return getCommentPairVo(idpId, comments);
     }
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/comment/adaptor/CommentAdapter.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/comment/adaptor/CommentAdapter.java
@@ -71,6 +71,15 @@ public class CommentAdapter
     }
 
     @Override
+    public List<Comment> findByApplicantIdAndIdpId(String applicantId, Long idpId) {
+        List<Comment> comments = commentRepository.findByApplicantIdAndIdpId(applicantId, idpId);
+        if (comments.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return comments;
+    }
+
+    @Override
     public CommentLike saveCommentLike(CommentLike commentLike) {
         return commentLikeRepository.save(commentLike);
     }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/comment/domain/CommentRepository.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/comment/domain/CommentRepository.java
@@ -13,6 +13,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByApplicantId(String applicantId);
 
+    List<Comment> findByApplicantIdAndIdpId(String applicantId, Long idpId);
+
     @Modifying
     @Query("delete from Comment c where c.idpId = :idpId")
     void deleteByIdpId(@Param("idpId") Long idpId);

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/CommentPairVo.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/CommentPairVo.java
@@ -22,7 +22,7 @@ public class CommentPairVo {
         return CommentPairVo.builder()
                 .id(comment.getId())
                 .createdAt(String.valueOf(Timestamp.valueOf(comment.getCreatedAt()).getTime()))
-                .content(isBlurred ? "블러 처리된 댓글입니다" : comment.getContent())
+                .content(isBlurred ? "자신의 댓글만 조회할 수 있습니다." : comment.getContent())
                 .isLike(isLike)
                 .likeCount(comment.getLikeCount())
                 .interviewerName(interviewerName)

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/CommentPairVo.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/CommentPairVo.java
@@ -15,17 +15,20 @@ public class CommentPairVo {
     private Boolean isLike;
     private Integer likeCount;
     private Boolean canEdit;
+    private Boolean isBlurred;
 
     public static CommentPairVo of(
-            Comment comment, Boolean isLike, String interviewerName, Boolean canEdit) {
+            Comment comment, Boolean isLike, String interviewerName, Boolean canEdit, Boolean isBlurred) {
         return CommentPairVo.builder()
                 .id(comment.getId())
                 .createdAt(String.valueOf(Timestamp.valueOf(comment.getCreatedAt()).getTime()))
-                .content(comment.getContent())
+                .content(isBlurred ? "블러 처리된 댓글입니다" : comment.getContent())
                 .isLike(isLike)
                 .likeCount(comment.getLikeCount())
                 .interviewerName(interviewerName)
                 .canEdit(canEdit)
+                .isBlurred(isBlurred)
                 .build();
     }
 }
+

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CommentLoadPort.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/out/CommentLoadPort.java
@@ -11,4 +11,6 @@ public interface CommentLoadPort {
     List<Comment> findByCardId(Long cardId);
 
     List<Comment> findByApplicantId(String applicantId);
+
+    List<Comment> findByApplicantIdAndIdpId(String applicantId, Long idpId);
 }


### PR DESCRIPTION
### 개요
close #389 

###  작업사항
- 코멘트 조회 시 TF들은 서로의 코멘트를 볼 수 없고 자신의 코멘트만 조회할 수 있도록 하였습니다. 

### 변경로직
- 코멘트 조회 시 회장단, 관리자 권한을 가진 사람들은 모든 코멘트를 조회할 수 있으나
- 그 외의 권한은 자신의 코멘트를 제외하고 블러 처리된 코멘트를 확인합니다. 


### reference

- 1차 논의가 시작되면 모든 코멘트를 조회할 수 있는 기능을 만드려고 했으나 현재 그 기간을 저희가 관리하고 있지 않기 때문에
- 회장단을 위한 API를 하나 만들어야할 것 같습니다.
- 해당 PR 머지되면 작업하도록 하겠습니다. 

조금 더 구체적으로 말씀드리면,  관리하고 있는 기간은 `지원서접수마감`과 `1차논의끝`이 있습니다. 그러나 지원서 접수가 끝나고 나서 TF들의 코멘트 작업이 있고 코멘트 전체 공개의 기준이 되는 시간은 1차 회의 시작 시간입니다. 1차 회의 시작 시간은 비공식 일정이기 때문에 이를 환경변수로 추가로 관리하는 것보다 회장단을 위한 코멘트 전체 공개 API를 만드는 것이 좋아보입니다!