### PR TITLE
[BE-149] 지원서 접수 시작/마감시간 설정 시 시간 형식 변경 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/controller/RecruitmentController.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/recruitment/controller/RecruitmentController.java
@@ -46,11 +46,8 @@ public class RecruitmentController {
                     """)
     @PostMapping("/recruitment")
     public ResponseEntity<Long> setUpRecruitment(@RequestBody RecruitmentSetUpDto request) {
-        ZoneId kst = ZoneId.of("Asia/Seoul");
-        LocalDateTime startAt =
-                Instant.ofEpochMilli(request.getStartAt()).atZone(kst).toLocalDateTime();
-        LocalDateTime endAt =
-                Instant.ofEpochMilli(request.getEndAt()).atZone(kst).toLocalDateTime();
+        LocalDateTime startAt = request.getStartAt();
+        LocalDateTime endAt = request.getEndAt();
 
         if (startAt.isAfter(endAt)) throw RecruitmentInValidDateException.EXCEPTION_1;
         if (startAt.isBefore(LocalDateTime.now()))

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/RecruitmentSetUpDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/RecruitmentSetUpDto.java
@@ -1,5 +1,8 @@
 package com.econovation.recruitdomain.domains.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,8 +11,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecruitmentSetUpDto {
-
     private Integer year;
-    private Long startAt;
-    private Long endAt;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startAt;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endAt;
 }


### PR DESCRIPTION
### 개요
close #391 

###  작업사항
- 지원서 접수 시작/마감시간 설정 시 시간 형식을 long에서 LocalDateTime으로 변경했습니다. 

### 변경로직
- 이제 테스트할 때 다음 형식으로 요청할 수 있습니다. 

```
{
  "year": 30,
  "startAt": "2026-02-14T23:38:00",
  "endAt": "2026-02-15T19:30:00"
}
```

### reference

- @rlajm1203 종민님 지금 하고 계시는 인프라 작업에 서버 시간 KST로 설정하는 것도 진행해주시면 감사하겠습니다!