### PR TITLE
[BE-156] 운영 환경에서 Swagger 접속을 막기

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtExceptionFilter.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtExceptionFilter.java
@@ -1,10 +1,13 @@
 package com.econovation.recruit.api.config.security;
 
+import static com.econovation.recruitcommon.consts.RecruitStatic.SwaggerPatterns;
+
 import com.econovation.recruitcommon.exception.BaseErrorCode;
 import com.econovation.recruitcommon.exception.ErrorResponse;
 import com.econovation.recruitcommon.exception.RecruitCodeException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Arrays;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -12,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
@@ -31,6 +35,14 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
                     response,
                     getErrorResponse(e.getErrorCode(), request.getRequestURL().toString()));
         }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        AntPathMatcher antPathMatcher = new AntPathMatcher();
+        return Arrays.stream(SwaggerPatterns)
+                .anyMatch(pattern -> antPathMatcher.match(pattern, path));
     }
 
     private ErrorResponse getErrorResponse(BaseErrorCode errorCode, String path) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtTokenFilter.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtTokenFilter.java
@@ -3,11 +3,14 @@ package com.econovation.recruit.api.config.security;
 import static com.econovation.recruitcommon.consts.RecruitStatic.AUTH_HEADER;
 import static com.econovation.recruitcommon.consts.RecruitStatic.BEARER;
 
+import static com.econovation.recruitcommon.consts.RecruitStatic.SwaggerPatterns;
+
 import com.econovation.recruitcommon.dto.AccessTokenInfo;
 import com.econovation.recruitcommon.exception.InvalidTokenException;
 import com.econovation.recruitcommon.jwt.JwtTokenProvider;
 import com.econovation.recruitdomain.out.WhitelistLoadPort;
 import java.io.IOException;
+import java.util.Arrays;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
@@ -19,6 +22,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
 
@@ -45,6 +49,14 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        AntPathMatcher antPathMatcher = new AntPathMatcher();
+        return Arrays.stream(SwaggerPatterns)
+                .anyMatch(pattern -> antPathMatcher.match(pattern, path));
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/SecurityConfig.java
@@ -64,9 +64,11 @@ public class SecurityConfig {
         // 베이직 시큐리티는 ExceptionTranslationFilter 에서 authenticationEntryPoint 에서
         // commence 로 401 넘겨줌. -> 응답 헤더에 www-authenticate 로 인증하라는 응답줌.
         // 브라우저가 basic auth 실행 시켜줌.
-        // 개발 환경에서만 스웨거 비밀번호 미설정.
+        // 스웨거 설정: 운영 환경은 차단, 그 외(로컬/개발)는 permitAll
         if (springEnvironmentHelper.isProdProfile()) {
-            http.authorizeRequests().mvcMatchers(SwaggerPatterns).authenticated().and().httpBasic();
+            http.authorizeRequests().mvcMatchers(SwaggerPatterns).denyAll();
+        } else {
+            http.authorizeRequests().mvcMatchers(SwaggerPatterns).permitAll();
         }
 
         http.authorizeRequests()
@@ -120,7 +122,6 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web ->
                 web.ignoring()
-                        .antMatchers(SwaggerPatterns)
                         .antMatchers(
                                 HttpMethod.POST,
                                 "/api/v1/applicants/mail",

--- a/server/Recruit-Api/src/main/resources/application.yml
+++ b/server/Recruit-Api/src/main/resources/application.yml
@@ -134,6 +134,11 @@ spring:
   config:
     activate:
       on-profile: prod
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
 logging:
   level:
     ROOT: WARN

--- a/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/ncp/NcpClients.java
+++ b/server/Recruit-Infrastructure/src/main/java/com/econovation/recruitinfrastructure/ncp/NcpClients.java
@@ -10,7 +10,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 
 public class NcpClients {
 
-    @FeignClient(name = "NcpClient", url = "${ncp.mail-base-url}", configuration = NcpConfig.class)
+    @FeignClient(
+            name = "NcpMailClient",
+            contextId = "ncpMailClient",
+            url = "${ncp.mail-base-url}",
+            configuration = NcpConfig.class)
     @Headers("Content-Type: application/json; charset=UTF-8")
     public interface NcpMailClient {
         @PostMapping(path = "${ncp.mail-api-url}", consumes = "application/json; charset=UTF-8")
@@ -22,7 +26,11 @@ public class NcpClients {
                 @RequestBody SendRawEmailDto sendRawEmailDto);
     }
 
-    @FeignClient(name = "NcpClient", url = "${ncp.sms-base-url}", configuration = NcpConfig.class)
+    @FeignClient(
+            name = "NcpSmsClient",
+            contextId = "ncpSmsClient",
+            url = "${ncp.sms-base-url}",
+            configuration = NcpConfig.class)
     @Headers("Content-Type: application/json; charset=UTF-8")
     public interface NcpSmsClient {
         @PostMapping(path = "${ncp.sms-api-url}", consumes = "application/json;")


### PR DESCRIPTION
### 개요
close #404 

###  작업사항
- 운영 환경(prod)에서 Swagger 관련 엔드포인트가 노출/생성되지 않도록 설정을 추가했습니다.
- Swagger 경로를 보안 필터 체인에 포함시키고, 환경별로 Swagger 접근 정책을 분리했습니다.
- 환경은 운영용 vs 운영용이 아닌 것으로 분리했습니다.
- Swagger 경로에 대해서는 JWT 필터가 동작하지 않도록 제외하는 로직을 추가했습니다.

### 변경로직

#### prod 환경
- `application.yml`에서 Springdoc 설정을 비활성화하여 Swagger 문서/화면이 생성되지 않도록 처리했습니다.
  - `springdoc.api-docs.enabled=false`
  - `springdoc.swagger-ui.enabled=false`
- `SecurityConfig`에서 Swagger 경로는 `denyAll()`로 완전 차단하도록 변경했습니다.  

#### non-prod (local/dev) 환경
- `SecurityConfig`에서 Swagger 경로는 `permitAll()`로 자유 접근 가능하도록 유지했습니다.

#### JWT 필터 처리 방식
- Swagger 경로의 인증/인가 정책은 `SecurityConfig`에서 담당하도록 역할을 명확히 분리했습니다.
- `JwtTokenFilter`, `JwtExceptionFilter`에서 `shouldNotFilter()`를 오버라이드하여  
  `SwaggerPatterns`에 매칭되는 경우 JWT 필터가 동작하지 않도록 처리했습니다.

### 테스트 화면
<img width="788" height="676" alt="image" src="https://github.com/user-attachments/assets/841a94a0-ee79-412b-a0ee-a3362d15291c" />
위의 사진에서 보이는 Active Profile이 local, dev일 경우엔 swagger 화면이 잘 나타나고 prod일 경우엔 나오지 않습니다.

#### prod일 경우 스웨거 접속시 화면
<img width="540" height="374" alt="image" src="https://github.com/user-attachments/assets/26c7a2b1-faaf-4d87-904c-4cffd9faff19" />

 ### 추가 변경사항                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  - Active Profile이 dev 또는 prod 에서 애플리케이션 기동 시 `The bean 'NcpClient.FeignClientSpecification' could not be registered` 에러가 발생하던 문제를 수정했습니다.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - 원인: NcpMailClient, NcpSmsClient가 동일한 Feign name("NcpClient")을 사용해 동일 스펙 빈이 중복 등록되었기 때문입니다.                                                                                                                                                                                                        
  - 조치: 각 Feign Client의 name/contextId를 분리하여 충돌을 제거했습니다.                                                                                                                                                                                                                                          
      - NcpMailClient → name = "NcpMailClient", contextId = "ncpMailClient"                                                                                                                                                                                                                                         
      - NcpSmsClient → name = "NcpSmsClient", contextId = "ncpSmsClient" 
- local에서는 spring.main.allow-bean-definition-overriding=true 설정이 있어 중복 빈이 덮어써져 문제가 드러나지 않았습니다.                                                                                                                                                                                        