### PR TITLE
[BE-160] mongodb 중복 키 예외에 대해서 axonserver에서 재시도하지 않도록 함 

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/applicant/aggregate/AnswerCreatedEventListener.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Slf4j
 @RequiredArgsConstructor
+@ProcessingGroup("mongoEventProcessor")
 public class AnswerCreatedEventListener {
     private final MongoAnswerAdaptor answerAdaptor;
 

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/AxonConfig.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/AxonConfig.java
@@ -18,7 +18,9 @@ public class AxonConfig {
     }
 
     @Autowired
-    public void configure(EventProcessingConfigurer configurer) {
+    public void configure(EventProcessingConfigurer configurer,
+                          DuplicateKeyErrorHandler errorHandler) {
         configurer.registerTrackingEventProcessor("mongoEventProcessor");
+        configurer.registerListenerInvocationErrorHandler("mongoEventProcessor", conf -> errorHandler);
     }
 }

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/DuplicateKeyErrorHandler.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/DuplicateKeyErrorHandler.java
@@ -1,0 +1,26 @@
+package com.econovation.recruitdomain.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.EventMessageHandler;
+import org.axonframework.eventhandling.ListenerInvocationErrorHandler;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DuplicateKeyErrorHandler implements ListenerInvocationErrorHandler {
+
+    @Override
+    public void onError(Exception exception, EventMessage<?> event, EventMessageHandler eventHandler) throws Exception {
+        if (isDuplicateKeyException(exception)) {
+            log.warn("중복 데이터 무시 - eventId: {}", event.getIdentifier());
+            return;
+        }
+        throw exception;
+    }
+
+    private boolean isDuplicateKeyException(Exception e) {
+        return e instanceof DuplicateKeyException;
+    }
+}

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/SignUpRequestDto.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/domains/dto/SignUpRequestDto.java
@@ -3,6 +3,7 @@ package com.econovation.recruitdomain.domains.dto;
 import com.econovation.recruitcommon.annotation.PasswordValidate;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
 
@@ -10,7 +11,8 @@ import lombok.Getter;
 @Getter
 public class SignUpRequestDto {
     @NotBlank private String name;
-    @NotBlank private Integer year;
+    @NotNull
+    private Integer year;
     @Email private String email;
     @PasswordValidate private String password;
 }


### PR DESCRIPTION
### 개요
close #413 

###  작업사항
- DuplicateKeyErrorHandler 추가 (ListenerInvocationErrorHandler 구현)
  - DuplicateKeyException은 예외를 삼켜 재시도 없이 무시
  - 그 외 예외는 Axon에 위임하여 기존 재시도 동작 유지
- AnswerCreatedEventListener에 @ProcessingGroup("mongoEventProcessor") 추가
- AxonConfig에 해당 그룹에 에러 핸들러 등록


### reference

- axonserver의 예외 핸들러는 `ListenerInvocationErrorHandler` 이거랑 `ErrorHandler` 이게 있는데 후자가 상위 레벨이라 하위 레벨에서 처리하도록 전자를 사용합니다. 
- 시간 얼마 안 남은 만큼 빠른 머지하겠습니다.