### PR TITLE
[BE-162]: 지원서 생성 시 보드 연결 순서 오류 수정

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/card/service/BoardService.java
@@ -164,8 +164,6 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
 
     @Override
     public void createApplicantBoard(String applicantId, String hopeField, Long cardId) {
-        //        \"hopeField\" -> hopeField 로 변경
-        hopeField = hopeField;
         Integer year = latestRecruitmentVo.getYear();
         if (hopeField.equals("개발자") || hopeField.equals("디자이너") || hopeField.equals("기획자")) {
             log.info("ApplicantBoard 생성 : {}, applicantId : {}", hopeField, applicantId);
@@ -176,6 +174,9 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
 
         Columns column = columnLoadPort.getColumnByYearAndTitle(hopeField, year);
 
+        //        기존에 null 인 nextBoardId를 현재 boardId로 업데이트
+        List<Board> existingBoards =
+                boardLoadPort.getBoardByNavigationIdAndColumnsId(1, column.getId());
         Board board =
                 Board.builder()
                         .cardType(CardType.APPLICANT)
@@ -185,14 +186,15 @@ public class BoardService implements BoardLoadUseCase, BoardRegisterUseCase {
                         .cardId(cardId)
                         .build();
         Board save = boardRecordPort.save(board);
-        //        기존에 null 인 nextBoardId를 현재 boardId로 업데이트
-        boardLoadPort.getBoardByNavigationIdAndColumnsId(1, column.getId()).stream()
-                .filter(b -> b.getNextBoardId() == null)
-                .findFirst()
-                .ifPresent(
-                        b -> {
-                            b.updateNextBoardID(save.getId());
-                        });
+        if (!existingBoards.isEmpty()) {
+            existingBoards.stream()
+                    .filter(b -> b.getNextBoardId() == null)
+                    .findFirst()
+                    .ifPresent(
+                            b -> {
+                                b.updateNextBoardID(save.getId());
+                            });
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- `createApplicantBoard`에서 보드 저장(`save()`) **이후**에 기존 목록을 조회하던 순서를 수정
- `save()` 이후 조회 시 새 보드(`nextBoardId = null`)도 목록에 포함되어, `findFirst()`가 새 보드 자신을 반환할 경우 **자기 참조 포인터**가 생성되는 버그 수정
- 빈 목록 체크(`isEmpty()`) 추가 — `createWorkBoard`와 동일한 방어 로직 적용
- 의미 없는 자기 대입 코드(`hopeField = hopeField`) 제거

## Test plan
- [ ] 지원서 제출 후 칸반 보드에 카드가 올바른 컬럼에 생성되는지 확인
- [ ] 지원서 여러 개 연속 제출 시 linked list 순서가 올바르게 유지되는지 확인