### PR TITLE
[BE-163] JwtTokenFilter에서 화이트리스트 토큰 조회 전에 null 체크를 수행

### DIFF
--- a/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtTokenFilter.java
+++ b/server/Recruit-Api/src/main/java/com/econovation/recruit/api/config/security/JwtTokenFilter.java
@@ -38,14 +38,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         String token = resolveToken(request);
 
-        if (!whitelistLoadPort.existsByToken(token)) {
+        if (token == null || !whitelistLoadPort.existsByToken(token)) {
             throw InvalidTokenException.EXCEPTION;
         }
 
-        if (token != null) {
-            Authentication authentication = getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-        }
+        Authentication authentication = getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }


### PR DESCRIPTION
### 개요
close #419 

###  작업사항
- JwtTokenFilter에서 화이트리스트 토큰 조회 전에 null 체크를 수행합니다. 

### 변경로직
(전) 
현재 운영서버에서 특정 에러 로그가 쌓여있음. 토큰 미포함시 화이트리스트 저장소 조회할 때 NPE 발생 
-> 인증이 필요한 API에 토큰 안 담아서 보내면 로컬에서도 똑같은 에러 로그 확인 가능

(후)
null 체크 이후로는 에러 로그 발생하지 않고 401 응답이 옴 


### reference

- 엄 보기 싫은 에러 로그가 쌓인다는 문제만 있고 화이트리스트가 제대로 동작 안 하거나 이런 건 아니어서 운영서버에 급하게 반영해야할 사항은 아닙니다.