### PR TITLE
[BE-167] 운영 환경에서 prod 프로필이 적용되도록 Jib 실행 설정 수정

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - backend
 env:
-  SPRING_PROFILES_ACTIVE: local
+  SPRING_PROFILES_ACTIVE: prod
   ENVIRONMENT: production
   IMAGE_NAME: blackbean99/econo-recruit
   SERVICE_NAME: Econovation_Recruit_Server

--- a/server/Recruit-Api/build.gradle
+++ b/server/Recruit-Api/build.gradle
@@ -81,7 +81,7 @@ jib {
     }
     container {
         jvmFlags = [
-                '-Dspring.profiles.active=local',
+                '-Dspring.profiles.active=' + (System.getenv("ACTIVE_PROFILE") ?: "local"),
                 '-Dserver.port=' + serverPort,
                 '-Xms2G', '-Xmx2G',
                 '-XX:+UseG1GC',


### PR DESCRIPTION
### 관련 이슈
close #427 

### 작업 내용
- 운영 상위 워크플로우(`prod.yml`)의 `SPRING_PROFILES_ACTIVE` 값을 `prod`로 수정했습니다.
- Jib 이미지 실행 시 `spring.profiles.active`가 `local`로 하드코딩되어 있던 부분을 제거하고, `ACTIVE_PROFILE` 환경변수 기반으로 동작하도록 수정했습니다.

### 문제 원인
운영 서버의 `.env`에는 이미 `PROFILE=prod`가 설정되어 있었지만, 실제 실행 중인 컨테이너를 확인해보니 Jib 이미지의 Java 실행 인자에 아래 값이 하드코딩되어 있었습니다.

```text
-Dspring.profiles.active=local
```

즉 운영 서버 환경변수와 무관하게, 실제 애플리케이션은 local 프로필로 기동되고 있었습니다.

그 결과:

- prod 프로필에서 비활성화되어야 하는 springdoc 설정이 적용되지 않았고
- 운영 환경에서도 Swagger UI 및 API Docs에 접근이 가능했습니다.

### 변경 이유

Swagger 차단 로직 자체는 이미 코드에 반영되어 있었지만, 운영 환경에서 실제 실행 프로필이 local로 고정되어 있어 의도대로 동작하지 않았습니다.

이번 수정으로:

- 운영 배포 워크플로우는 prod 프로필을 명시적으로 전달하고
- Jib 이미지도 해당 값을 실제 Java 실행 인자에 반영하도록 수정했습니다.

### 영향 범위

- 운영 배포 워크플로우(.github/workflows/prod.yml)
- 백엔드 Jib 이미지 실행 설정(server/Recruit-Api/build.gradle)
- dev, local 환경은 ACTIVE_PROFILE 값이 없을 경우 기존처럼 local 기본값을 사용합니다.

### 기대 결과

- 운영 환경에서는 애플리케이션이 prod 프로필로 기동됩니다.
- prod 프로필의 springdoc 비활성화 및 Swagger 접근 차단 설정이 정상 적용됩니다.
- dev, local 환경에서는 기존처럼 Swagger 접근이 가능합니다.

### 확인 사항

운영 서버에서 실행 중인 컨테이너를 확인한 결과, 기존 이미지가 아래와 같이 local 프로필로 실행되고 있음을 확인했습니다. 확인 후 이에 문제가 있었다는 것을 파악하고 위 작업을 진행하였습니다.
<img width="878" height="460" alt="image" src="https://github.com/user-attachments/assets/5cac4e49-6780-4418-b7b8-aa74b5135e54" />