### PR TITLE
[BE-169] 인프라 개편 및 가상 스레드 활성화

### DIFF
--- a/server/Recruit-Api/src/main/resources/application.yml
+++ b/server/Recruit-Api/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  threads:
+    virtual:
+      enabled: true
   profiles:
     include:
       - infrastructure

--- a/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/EnableAsyncConfig.java
+++ b/server/Recruit-Domain/src/main/java/com/econovation/recruitdomain/config/EnableAsyncConfig.java
@@ -6,12 +6,24 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
 @EnableAsync
 @Configuration
 @RequiredArgsConstructor
 public class EnableAsyncConfig implements AsyncConfigurer {
 
     private final CustomAsyncExceptionHandler customAsyncExceptionHandler;
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual()
+                        .name("async-virtual-thread-", 0)
+                        .factory()
+        );
+    }
 
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {

--- a/server/docker-compose.local.yml
+++ b/server/docker-compose.local.yml
@@ -1,0 +1,53 @@
+name: econo-recruit-local
+
+services:
+  mysql:
+    image: mysql:8.0.36
+    container_name: mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+  mongodb:
+    image: mongo:6.0.13
+    container_name: mongodb
+    restart: unless-stopped
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+
+  axon-server:
+    image: axoniq/axonserver:4.6.11
+    container_name: axon-server
+    restart: unless-stopped
+    ports:
+      - "8024:8024"
+      - "8124:8124"
+    volumes:
+      - axon-data:/axonserver/data
+      - axon-events:/axonserver/events
+      - axon-config:/axonserver/config
+
+volumes:
+  mysql-data:
+  mongo-data:
+  redis-data:
+  axon-data:
+  axon-events:
+  axon-config:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,10 +1,35 @@
-version: "3.7"
+name: econo-recruit
 services:
+  mysql:
+    image: mysql:8.0.36
+    container_name: mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+  mongodb:
+    image: mongo:6.0.13
+    container_name: mongodb
+    restart: unless-stopped
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    volumes:
+      - mongo-data:/data/db
+
   redis:
     image: redis:alpine
-    hostname: redis
     container_name: redis
-    network_mode: "host"
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
 
   axon-server:
     image: axoniq/axonserver:4.6.11
@@ -13,6 +38,10 @@ services:
     ports:
       - "8024:8024"
       - "8124:8124"
+    volumes:
+      - axon-data:/axonserver/data
+      - axon-events:/axonserver/events
+      - axon-config:/axonserver/config
 
   backend:
     image: blackbean99/econo-recruit:latest
@@ -26,13 +55,30 @@ services:
     depends_on:
       - redis
       - axon-server
+      - mysql
+      - mongodb
 
-  nginx:
-    image: nginx:1.21.5-alpine
-    container_name: myweb-proxy
-    network_mode: "host"
+  nginx-proxy-manager:
+    image: jc21/nginx-proxy-manager:latest
+    container_name: nginx-proxy-manager
+    restart: unless-stopped
+    ports:
+      - "10023:443"
+      - "127.0.0.1:81:81"
     volumes:
-      - ./proxy/nginx.conf:/etc/nginx/nginx.conf
-      - ./proxy/ssl:/etc/ssl
+      - npm-data:/data
+      - npm-letsencrypt:/etc/letsencrypt
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - backend
+
+volumes:
+  mysql-data:
+  mongo-data:
+  redis-data:
+  axon-data:
+  axon-events:
+  axon-config:
+  npm-data:
+  npm-letsencrypt:


### PR DESCRIPTION
### 개요
close #430

Docker Compose 구성을 개편하고 로컬 개발용 Compose 파일을 추가했습니다.  
또한 비동기 작업과 Spring 기본 스레드 처리에 가상 스레드를 적용했습니다.

### 작업사항
- 기존 `docker-compose.yml`에 MySQL, MongoDB, Redis, Axon Server, Backend, Nginx Proxy Manager 구성을 정리
- MySQL, MongoDB, Redis, Axon Server, Nginx Proxy Manager 데이터 볼륨 추가
- 기존 nginx 컨테이너를 Nginx Proxy Manager 기반 구성으로 변경
- 로컬 인프라 실행용 `docker-compose.local.yml` 추가
- Spring virtual thread 설정 활성화
- `@Async` 작업에서 virtual thread executor를 사용하도록 설정

### 변경로직
- 운영 compose에서 DB, MongoDB, Redis, Axon Server를 함께 관리하도록 구성하고, 각 서비스의 데이터가 named volume에 저장되도록 변경했습니다.
- Backend는 기존처럼 host network를 사용하되, Redis/Axon뿐 아니라 MySQL/MongoDB 의존성도 명시했습니다.
- 프록시 구성을 직접 nginx 설정 파일 마운트 방식에서 Nginx Proxy Manager 방식으로 변경했습니다.
- 로컬 개발 환경에서는 backend/proxy 없이 MySQL, MongoDB, Redis, Axon Server만 띄울 수 있도록 별도 compose 파일을 분리했습니다.
- `spring.threads.virtual.enabled=true`를 추가하고 `AsyncConfigurer`에서 virtual thread executor를 반환하도록 변경해 I/O 대기가 많은 비동기 작업의 thread 점유를 줄였습니다.

### reference
- Java Virtual Threads
- Spring Boot `spring.threads.virtual.enabled`
- Docker Compose named volumes